### PR TITLE
feat: modify detector to let it detect functional transformers

### DIFF
--- a/pnpxai/core/experiment/auto_experiment.py
+++ b/pnpxai/core/experiment/auto_experiment.py
@@ -46,7 +46,7 @@ class AutoExperiment(Experiment):
     @staticmethod
     def recommend(model: Model, question: Question, task: Task) -> RecommenderOutput:
         detector = ModelArchitectureDetector()
-        model_arch = detector(model).architecture
+        model_arch = detector(model)
 
         recommender = XaiRecommender()
         recommender_out = recommender(question, task, model_arch)

--- a/pnpxai/detector/detector.py
+++ b/pnpxai/detector/detector.py
@@ -1,48 +1,87 @@
 from dataclasses import dataclass
+
+from torch import nn
+import torch.nn.functional as F
+
 from ._core import ModelArchitecture
 
 @dataclass
-class DetectorOutput:
-    architecture: set
+class ModelArchitectureSummary:
+    has_linear: bool
+    has_conv: bool
+    has_rnn: bool
+    has_transformer: bool
+
+    @property
+    def representative(self):
+        if (
+            self.has_linear
+            and not self.has_conv
+            and not self.has_rnn
+            and not self.has_transformer
+        ):
+            return "linear"
+        elif (
+            self.has_conv
+            and not self.has_rnn
+            and not self.has_transformer
+        ):
+            return "cnn"
+        elif self.has_transformer:
+            return "transformer"
+        else:
+            raise Exception("Cannot determine the representative of model architecture.")
 
 
 class ModelArchitectureDetector:
-    """
-    Detects the architecture of a model by analyzing its modules.
-
-    Attributes:
-    - modules: A list to store detected modules.
-    """
-    def __init__(self):
-        self.modules = []
-    
-    def extract_modules(self, model):
-        """
-        Extracts modules from the model.
-
-        Args:
-        - model: The model from which to extract modules.
-        """
-        module_mode = model.training
-        model.eval()
-
-        ma = ModelArchitecture(model)
-        for n in ma.list_nodes():
-            if n.opcode == "call_module":
-                self.modules.append(n.operator)
-        model.training = module_mode
-
     def __call__(self, model):
-        """
-        Calls the ModelArchitectureDetector object.
-
-        Args:
-        - model: The model to analyze.
-
-        Returns:
-        - DetectorOutput: An object containing the detected architecture.
-        """
-        self.extract_modules(model)
-        return DetectorOutput(
-            architecture = set([type(module) for module in self.modules])
+        ma = ModelArchitecture(model)
+        return ModelArchitectureSummary(
+            has_linear=_has_linear(ma),
+            has_conv=_has_conv(ma),
+            has_rnn=_has_rnn(ma),
+            has_transformer=_has_transformer(ma),
         )
+
+
+_is_module_of = lambda node, module: node.opcode == "call_module" and isinstance(node.operator, module)
+_is_function_of = lambda node, func: node.opcode == "call_function" and node.operator is func
+
+def _has_linear(ma: ModelArchitecture):
+    linear_node = ma.find_node(
+        lambda node: (
+            _is_module_of(node, nn.Linear)
+            or _is_function_of(node, F.linear)
+        )
+    )
+    return linear_node is not None
+
+def _has_conv(ma: ModelArchitecture):
+    conv_node = ma.find_node(
+        lambda node: (
+            _is_module_of(node, nn.Conv1d)
+            or _is_module_of(node, nn.Conv2d)
+            or _is_function_of(node, F.conv1d)
+            or _is_function_of(node, F.conv2d)
+        )
+    )
+    return conv_node is not None
+
+def _has_rnn(ma: ModelArchitecture):
+    rnn_node = ma.find_node(
+        lambda node: (
+            _is_module_of(node, nn.RNN)
+        )
+    )
+    return rnn_node is not None
+
+def _has_transformer(ma: ModelArchitecture):
+    transformer_node = ma.find_node(
+        lambda node: (
+            _is_module_of(node, nn.Transformer)
+            or _is_module_of(node, nn.MultiheadAttention)
+            or _is_function_of(node, F.scaled_dot_product_attention)
+        )
+    )
+    return transformer_node is not None
+

--- a/tutorials/detector.py
+++ b/tutorials/detector.py
@@ -1,13 +1,11 @@
 from _operator import add
 import torchvision
+import timm
 from pnpxai.detector import ModelArchitectureDetector
 from pnpxai.recommender import XaiRecommender
 
-model = torchvision.models.get_model("vit_b_16").eval()
-
+model = timm.create_model("vit_small_patch8_224")
 detector = ModelArchitectureDetector()
-detector_output = detector(model, sample=None)
-
 recommender = XaiRecommender()
-applicables = recommender.filter_methods("why", "image", detector_output.architecture)
+applicables = recommender.filter_methods("why", "image", detector(model))
 print(applicables)


### PR DESCRIPTION
This PR modifies
- detector.py
	- add the new output type `ModelArchitectureSummary` which returns a representative type of model architecture as a string ticker
- recommender.py
	- move the maps out of the component and rename them
	- change the keys of the map `ARCHITECTURE_TO_EXPLAINERS` (`self.architecture_table` in previous) to the string tickers
	- modify `filter_methods`: the filtering condtions were moved to detector: `ModelArchitectureSummary.representative`, `_has_linear`, `_has_conv`, `_has_rnn`, and `_has_transformer`
	- @seongun-kim I want review or double-check around here, especially, whether `ModelArchitectureSummary.representative` is aligned to your first design.
- auto_experiment.py: modify detector/recommender part along with the changes above
	- @enver1323  I'm not sure this is the only part which depends on the changes. Could you please let me know if there is any other part which should be modified?
