### PR TITLE
feat: add inception v3 support

### DIFF
--- a/pnpxai/explainers/rap/rule_map.py
+++ b/pnpxai/explainers/rap/rule_map.py
@@ -21,7 +21,7 @@ SUPPORTED_OPS: Dict[str, Dict[str, Type[rules.RelProp]]] = {
     'call_function': {
         _operator.add: rules.Add,
         _operator.sub: rules.Sub,
-        _operator.mul: rules.RelPropSimple,
+        _operator.mul: rules.Mul,
         _operator.getitem: rules.GetItem,
         torch.add: rules.Add,
         torch.flatten: rules.Flatten,

--- a/pnpxai/explainers/rap/rule_map.py
+++ b/pnpxai/explainers/rap/rule_map.py
@@ -12,6 +12,7 @@ SUPPORTED_OPS: Dict[str, Dict[str, Type[rules.RelProp]]] = {
         nn.MaxPool2d: rules.MaxPool2d,
         nn.AdaptiveAvgPool2d: rules.AdaptiveAvgPool2d,
         nn.AvgPool2d: rules.AvgPool2d,
+        nn.AvgPool1d: rules.AvgPool1d,
         nn.BatchNorm2d: rules.BatchNorm2d,
         nn.Linear: rules.Linear,
         nn.Conv2d: rules.Conv2d,
@@ -19,14 +20,24 @@ SUPPORTED_OPS: Dict[str, Dict[str, Type[rules.RelProp]]] = {
     },
     'call_function': {
         _operator.add: rules.Add,
+        _operator.sub: rules.Sub,
+        _operator.mul: rules.RelPropSimple,
+        _operator.getitem: rules.GetItem,
         torch.add: rules.Add,
         torch.flatten: rules.Flatten,
         torch.relu: rules.ReLU,
         torch.cat: rules.Cat,
+        torch.transpose: rules.Flatten,
+        torch.sub: rules.Sub,
+        torch.unsqueeze: rules.Unsqueeze,
+        F.avg_pool2d: rules.AvgPool2d,
+        F.max_pool2d: rules.MaxPool2d,
         F.relu: rules.ReLU,
     },
     'call_method': {
         'add': rules.Add,
+        'sub': rules.Sub,
         'relu': rules.ReLU,
+        'transpose': rules.Flatten,
     }
 }

--- a/pnpxai/explainers/rap/rules.py
+++ b/pnpxai/explainers/rap/rules.py
@@ -1,3 +1,4 @@
+import _operator
 import torch
 import torch.nn as nn
 from torch import nn, Tensor
@@ -23,7 +24,7 @@ class RelProp:
         C = torch.autograd.grad(Z, X, S, retain_graph=True)
         return C
 
-    def relprop(self, rel: _TensorOrTensors, inputs: Optional[_TensorOrTensors], outputs: Optional[_TensorOrTensors]) -> _TensorOrTensors:
+    def relprop(self, rel: _TensorOrTensors, inputs: Optional[_TensorOrTensors], outputs: Optional[_TensorOrTensors], args=None, kwargs=None) -> _TensorOrTensors:
         return rel
 
 
@@ -41,7 +42,7 @@ class RelPropSimple(RelProp):
 
         return rel
 
-    def relprop(self, rel: _TensorOrTensors, inputs: _TensorOrTensors, outputs: _TensorOrTensors):
+    def relprop(self, rel: _TensorOrTensors, inputs: _TensorOrTensors, outputs: _TensorOrTensors, args=None, kwargs=None):
         if torch.is_tensor(rel):
             rel = [rel]
         rel = [self.backward(datum, inputs, outputs) for datum in rel]
@@ -67,23 +68,31 @@ class AdaptiveAvgPool2d(RelPropSimple):
     pass
 
 
+class AvgPool1d(RelPropSimple):
+    pass
+
+
 class AvgPool2d(RelPropSimple):
     pass
 
 
 class Add(RelPropSimple):
-    def relprop(self, rel: _TensorOrTensors, inputs: _TensorOrTensors, outputs: _TensorOrTensors):
+    def relprop(self, rel: _TensorOrTensors, inputs: _TensorOrTensors, outputs: _TensorOrTensors, args=None, kwargs=None):
         inputs = [F.relu(input) for input in inputs]
         outputs = torch.add(*inputs)
         return super().relprop(rel, inputs, outputs)
 
 
+class Sub(RelPropSimple):
+    pass
+
+
 class Flatten(RelProp):
-    def relprop(self, rel: _TensorOrTensors, inputs: _TensorOrTensors, outputs: _TensorOrTensors):
+    def relprop(self, rel: _TensorOrTensors, inputs: _TensorOrTensors, outputs: _TensorOrTensors, args=None, kwargs=None):
         return rel.reshape(inputs.shape)
 
 
-class Cat(RelProp):
+class Cat(RelPropSimple):
     def backward(self, rel: _TensorOrTensors, inputs: _TensorOrTensors, outputs: _TensorOrTensors):
         Sp = safe_divide(rel, outputs)
         Cp = self.gradprop(outputs, inputs, Sp)
@@ -205,16 +214,14 @@ class Linear(RelProp):
             (Rp + Rn).sum(dim=-1, keepdim=True)
         return Rp_tmp3 + Rn_tmp3
 
-    def relprop(self, R_p, inputs: Optional[_TensorOrTensors] = None, outputs: Optional[_TensorOrTensors] = None):
+    def relprop(self, R_p, inputs: _TensorOrTensors, outputs: _TensorOrTensors, args=None, kwargs=None):
         pw = torch.clamp(self.module.weight, min=0)
         nw = torch.clamp(self.module.weight, max=0)
         X = inputs
         px = torch.clamp(X, min=0)
         nx = torch.clamp(X, max=0)
-        if torch.is_tensor(R_p) == True and R_p.max() == 1:  # first propagation
-            pd = R_p
-
-            Rp_tmp = self.first_prop(pd, px, nx, pw, nw)
+        if torch.is_tensor(R_p) and R_p.max() == 1:  # first propagation
+            Rp_tmp = self.first_prop(R_p, px, nx, pw, nw)
             A = self.redistribute(Rp_tmp)
 
             return A
@@ -300,7 +307,7 @@ class Conv2d(RelProp):
             self.gradprop2(inputs, outputs, Sp, nw)
         return Rp
 
-    def relprop(self, R_p, inputs: Optional[_TensorOrTensors] = None, outputs: Optional[_TensorOrTensors] = None):
+    def relprop(self, R_p, inputs: _TensorOrTensors, outputs: _TensorOrTensors, args=None, kwargs=None):
         pw = torch.clamp(self.module.weight, min=0)
         nw = torch.clamp(self.module.weight, max=0)
         px = torch.clamp(inputs, min=0)
@@ -311,3 +318,20 @@ class Conv2d(RelProp):
         else:
             Rp = self.backward(R_p, px, nx, pw, nw)
         return Rp
+
+
+class GetItem(RelProp):
+    def relprop(self, rel: Tensor, inputs: Tensor, outputs: Tensor, args=None, kwargs=None):
+        rel_fill = torch.zeros_like(inputs)
+        rel_fill[args] = rel
+        return rel
+
+class Unsqueeze(RelProp):
+    def relprop(self, rel: Tensor, inputs: Tensor, outputs: Tensor, args=None, kwargs=None) -> _TensorOrTensors:
+        if 'input' in kwargs:
+            del kwargs['input']
+        else:
+            args = args[1:]
+        
+        rel = torch.squeeze(rel, *args, **kwargs)
+        return rel

--- a/pnpxai/messages.py
+++ b/pnpxai/messages.py
@@ -7,7 +7,8 @@ MESSAGES: Dict[str, str] = {
     'experiment.errors.explanation': 'Warning: Explaining {explainer} produced an error: {error}.',
     'experiment.errors.explainer_unsupported': 'Warning: {explainer} is not currently supported.',
     'elapsed': 'Computed {task} in {elapsed} sec',
-    'project.config.unsupported': 'Error: Config of type {config_type} is not supported'
+    'project.config.unsupported': 'Error: Config of type {config_type} is not supported',
+    'explainer.rap.errors.node': '{node} caused an error.',
 }
 
 

--- a/pnpxai/utils.py
+++ b/pnpxai/utils.py
@@ -77,3 +77,11 @@ def to_device(data, device: torch.device):
     if isinstance(data, dict):
         return {key: to_device(value, device) for key, value in data.items()}
     return data
+
+
+def flatten(data):
+    if isinstance(data, dict):
+        data = list(data.values())
+    if isinstance(data, (tuple, list)):
+        return sum([flatten(elem) for elem in data], [])
+    return [data]


### PR DESCRIPTION
This PR adds Inception V3 support.
The model has a transformation block, which does not have a gradient function:
```
x_ch0 = torch.unsqueeze(x[:, 0], 1) * (0.229 / 0.5) + (0.485 - 0.5) / 0.5
x_ch1 = torch.unsqueeze(x[:, 1], 1) * (0.224 / 0.5) + (0.456 - 0.5) / 0.5
x_ch2 = torch.unsqueeze(x[:, 2], 1) * (0.225 / 0.5) + (0.406 - 0.5) / 0.5
x = torch.cat((x_ch0, x_ch1, x_ch2), 1)
```
Having encountered an input node without a gradient function, I skip the propagation. Although, this works on this model, since shapes before and after transformation match, we may face shape mismatch issue in future.