### PR TITLE
Feat/tabular

### DIFF
--- a/pnpxai/explainers/__init__.py
+++ b/pnpxai/explainers/__init__.py
@@ -2,8 +2,8 @@ from pnpxai.explainers._explainer import Explainer, ExplainerWArgs
 from pnpxai.explainers.grad_cam import GradCam
 from pnpxai.explainers.guided_grad_cam import GuidedGradCam
 from pnpxai.explainers.integrated_gradients import IntegratedGradients
-from pnpxai.explainers.kernel_shap import KernelShap
-from pnpxai.explainers.lime import Lime
+from pnpxai.explainers.kernel_shap import KernelShap, TabKernelShap
+from pnpxai.explainers.lime import Lime, TabLime
 from pnpxai.explainers.rap import RAP
 from pnpxai.explainers.lrp import LRP
 from pnpxai.explainers.deep_lift import DeepLift

--- a/pnpxai/explainers/_explainer.py
+++ b/pnpxai/explainers/_explainer.py
@@ -11,7 +11,8 @@ class Explainer:
         model: Model,
     ):
         self.model = model
-        self.device = next(self.model.parameters()).device
+        if isinstance(model, Model):
+            self.device = next(self.model.parameters()).device
 
     @abstractmethod
     def attribute(self, inputs: DataSource, targets: DataSource, **kwargs) -> DataSource:

--- a/pnpxai/explainers/kernel_shap/__init__.py
+++ b/pnpxai/explainers/kernel_shap/__init__.py
@@ -1,1 +1,1 @@
-from pnpxai.explainers.kernel_shap.kernel_shap import KernelShap
+from pnpxai.explainers.kernel_shap.kernel_shap import KernelShap, TabKernelShap

--- a/pnpxai/explainers/lime/__init__.py
+++ b/pnpxai/explainers/lime/__init__.py
@@ -1,1 +1,1 @@
-from pnpxai.explainers.lime.lime import Lime
+from pnpxai.explainers.lime.lime import Lime, TabLime

--- a/tutorials/finance/tab_explainer.py
+++ b/tutorials/finance/tab_explainer.py
@@ -1,12 +1,4 @@
-import pickle
-
-import torch
 import numpy as np
-import pandas as pd
-import quantus as qt
-import qt_wrapper as qtw
-import seaborn as sns
-import matplotlib.pyplot as plt
 
 from pnpxai.explainers import TabKernelShap, TabLime
 from shap.utils._legacy import kmeans
@@ -16,7 +8,6 @@ import sklearn
 
 seed = 42
 np.random.seed(seed)
-torch.manual_seed(seed)
 # Load train and test data
 data = load_breast_cancer()
 X, y = data.data, data.target

--- a/tutorials/finance/tab_explainer.py
+++ b/tutorials/finance/tab_explainer.py
@@ -1,0 +1,78 @@
+import pickle
+
+import torch
+import numpy as np
+import pandas as pd
+import quantus as qt
+import qt_wrapper as qtw
+import seaborn as sns
+import matplotlib.pyplot as plt
+
+from pnpxai.explainers import TabKernelShap, TabLime
+from shap.utils._legacy import kmeans
+from xgboost import XGBClassifier, XGBRegressor
+from sklearn.datasets import fetch_california_housing, load_breast_cancer
+import sklearn
+
+seed = 42
+np.random.seed(seed)
+torch.manual_seed(seed)
+# Load train and test data
+data = load_breast_cancer()
+X, y = data.data, data.target
+X_train, X_test, y_train, y_test = sklearn.model_selection.train_test_split(X, y, train_size=0.80)
+
+clf_model = XGBClassifier()
+clf_model.fit(X_train, y_train)
+
+categorical_features = np.argwhere(np.array([len(set(X_train[:,x])) for x in range(X_train.shape[1])]) <= 10).flatten()
+bg_data = X_train
+explainer = TabLime(
+    clf_model, bg_data, categorical_features=categorical_features, mode='classification'
+)
+attribution = explainer.attribute(
+    X_test[:10],
+    targets=None,
+    n_samples=1000)
+
+print(attribution)
+
+bg_data = TabKernelShap.kmeans(X_train, 100)
+explainer = TabKernelShap(clf_model, bg_data, mode="classification")
+targets = clf_model.predict(X_test[:10])
+attribution = explainer.attribute(
+    X_test[:10],
+    targets=targets,
+    n_samples=1000)
+
+print(attribution)
+
+
+reg_model = XGBRegressor()
+housing = fetch_california_housing()
+train, test, labels_train, labels_test = sklearn.model_selection.train_test_split(housing.data, housing.target, train_size=0.80)
+reg_model.fit(train, labels_train)
+
+
+categorical_features = np.argwhere(np.array([len(set(train[:,x])) for x in range(train.shape[1])]) <= 10).flatten()
+bg_data = train
+explainer = TabLime(
+    reg_model, bg_data, categorical_features=categorical_features, mode='regression'
+)
+attribution = explainer.attribute(
+    test[:10],
+    targets=None,
+    n_samples=1000)
+
+print(attribution)
+
+bg_data = TabKernelShap.kmeans(train, 100)
+explainer = TabKernelShap(reg_model, bg_data, mode="regression")
+attribution = explainer.attribute(
+    test[:10],
+    targets=None,
+    n_samples=1000)
+
+print(attribution)
+
+


### PR DESCRIPTION
수정사항 : Tabular data용 SHAP, LIME 새로 구현(TabLime, TabKernelShap)

가능한 모델 : XGBoost의 classification 및 regression, Sklearn의 classification 및 regression, Callable

특이사항
1. Regression model을 추가
- 현재 package는 classification만 다루고 있으나, tabular는 regression도 포함해야 할 것 같아서 추가함. 다만 regression이 들어옴으로써 전체 framework에 공통적으로 적용되는 부분이 바뀔 수도 있을 것으로 보임.
2. Constructor에 training set이 필요함
- 기존 image 기반 Explainer와 달리 SHAP, LIME은 perturbation을 위해 training set 또는 그 일부를 전달하게 함.
3. attribute method에 target이 필요없는 경우가 있음
- Regression이 들어오는 경우 target이 필요없고, TabLime의 기초가 되는 lime package는 내부적으로 inference를 해서 target을 추가계산하기 때문에 classification의 경우도 target을 사용하지 않음.

