### PR TITLE
Feature/metrics modality support

### DIFF
--- a/pnpxai/core/experiment/auto_experiment.py
+++ b/pnpxai/core/experiment/auto_experiment.py
@@ -1,4 +1,4 @@
-from typing import Literal, Callable, Optional, Type
+from typing import Literal, Callable, Optional, Type, Union, Tuple
 
 from pnpxai.core.experiment.experiment import Experiment
 from pnpxai.core.detector import detect_model_architecture
@@ -9,16 +9,29 @@ from pnpxai.explainers import (
     CAM_BASED_EXPLAINERS,
     PERTURBATION_BASED_EXPLAINERS,
     GRADIENT_BASED_EXPLAINERS,
+    EXPLAINERS_FOR_TABULAR,
     IntegratedGradients,
 )
 from pnpxai.explainers.types import TargetLayerOrListOfTargetLayers, ForwardArgumentExtractor
-from pnpxai.explainers.utils import get_default_feature_mask_fn, get_default_baseline_fn
-
+from pnpxai.explainers.utils import (
+    get_default_feature_mask_fn,
+    get_default_baseline_fn,
+)
+from pnpxai.explainers.utils.postprocess import (
+    PostProcessor,
+    all_postprocessors,
+)
+from pnpxai.metrics import PIXEL_FLIPPING_METRICS
+from pnpxai.metrics.utils import get_default_channel_dim
 
 EXPLAINERS_NO_KWARGS = CAM_BASED_EXPLAINERS
 EXPLAINERS_FEATURE_MASK_AVAILABLE = PERTURBATION_BASED_EXPLAINERS
 EXPLAINERS_BASELINE_FN_AVAILABLE = PERTURBATION_BASED_EXPLAINERS + [IntegratedGradients]
 EXPLAINERS_LAYER_AVAILABLE = GRADIENT_BASED_EXPLAINERS
+EXPLAINERS_BG_DATA_REQUIRED = EXPLAINERS_FOR_TABULAR
+
+METRICS_BASELINE_FN_REQUIRED = PIXEL_FLIPPING_METRICS
+METRICS_CHANNEL_DIM_REQUIRED = PIXEL_FLIPPING_METRICS
 
 
 class AutoExperiment(Experiment):
@@ -44,85 +57,67 @@ class AutoExperiment(Experiment):
         modality: ModalityOrListOfModalities = "image",
         question: Question = "why",
         evaluator_enabled: bool = True,
-        layer: Optional[TargetLayerOrListOfTargetLayers] = None,
         input_extractor: Optional[Callable] = None,
         label_extractor: Optional[Callable] = None,
         target_extractor: Optional[Callable] = None,
-        forward_arg_extractor: Optional[ForwardArgumentExtractor] = None,
-        additional_forward_arg_extractor: Optional[ForwardArgumentExtractor] = None,
-        input_visualizer: Optional[Callable] = None,
-        target_visualizer: Optional[Callable] = None,
         target_labels: bool = False,
-        feature_mask_fn: Optional[Callable] = None,
-        baseline_fn: Optional[Callable] = None,
-        mask_token_id: Optional[int] = None,
+        channel_dim: Optional[int] = None,
+        **kwargs,
     ):
-        # # TODO: multimodal support
-        # if modality not in Modality.__args__:
-        #     raise NotImplementedError(f'AutoExperiment for {modality} is not supported.')
-
         if (modality == 'text' or 'text' in modality):
-            assert layer is not None, "Must have 'layer' for text modality. It might be a word embedding layer of your model."
+            assert kwargs.get('layer'), "Must have 'layer' for text modality. It might be a word embedding layer of your model."
+        if modality == 'tabular':
+            assert kwargs.get('background_data') is not None, "Must have 'background_data' for tabular modality."
 
         # recommender
         self.recommended = XaiRecommender().recommend(modality=modality, model=model)
 
         # explainers
-        explainer_kwargs = {
-            'forward_arg_extractor': forward_arg_extractor,
-            'additional_forward_arg_extractor': additional_forward_arg_extractor,
-        }
-        if layer is not None:
-            explainer_kwargs['layer'] = layer
-
         explainers = []
         for explainer_type in self.recommended.explainers:
             explainer_kwargs = {}
-            if explainer_type not in EXPLAINERS_NO_KWARGS:
-                explainer_kwargs['forward_arg_extractor'] = forward_arg_extractor
-                explainer_kwargs['additional_forward_arg_extractor'] = additional_forward_arg_extractor
+            if explainer_type in EXPLAINERS_BG_DATA_REQUIRED:
+                explainer_kwargs['background_data'] = kwargs.get('background_data')
+            elif explainer_type not in EXPLAINERS_NO_KWARGS:
+                explainer_kwargs['forward_arg_extractor'] = kwargs.get('forward_arg_extractor')
+                explainer_kwargs['additional_forward_arg_extractor'] = kwargs.get('additional_forward_arg_extractor')
                 if explainer_type in EXPLAINERS_FEATURE_MASK_AVAILABLE:
-                    explainer_kwargs['feature_mask_fn'] = get_default_feature_mask_fn(modality)
-                if explainer_type in EXPLAINERS_BASELINE_FN_AVAILABLE:    
-                    explainer_kwargs['baseline_fn'] = get_default_baseline_fn(modality, mask_token_id)
+                    explainer_kwargs['feature_mask_fn'] = kwargs.get('feature_mask_fn') \
+                        or get_default_feature_mask_fn(modality)
+                if explainer_type in EXPLAINERS_BASELINE_FN_AVAILABLE:
+                    explainer_kwargs['baseline_fn'] = kwargs.get('baseline_fn') \
+                        or get_default_baseline_fn(modality, mask_token_id=kwargs.get('mask_token_id') or 0)
                 if explainer_type in EXPLAINERS_LAYER_AVAILABLE:
-                    explainer_kwargs['layer'] = layer
+                    explainer_kwargs['layer'] = kwargs.get('layer')
             explainers.append(explainer_type(model, **explainer_kwargs))
-        metrics = [
-            metric_type(model)
-            for metric_type in self.recommended.metrics
-        ]
+
+        if modality == 'tabular' and evaluator_enabled:
+            raise NotImplementedError(f"Evaluator for {modality} is not supported yet.")
+
+        # channel dim for postprocess
+        channel_dim = channel_dim or get_default_channel_dim(modality)
+
+        # metrics but explainer is not assigned yet
+        # an explainer will be assigned when run the experiment
+        empty_metrics = []
+        for metric_type in self.recommended.metrics:
+            metric_kwargs = {}
+            if metric_type in METRICS_BASELINE_FN_REQUIRED:
+                metric_kwargs['baseline_fn'] = kwargs.get('baselin_fn') \
+                    or get_default_baseline_fn(modality, mask_token_id=kwargs.get('mask_token_id') or 0)
+            if metric_type in METRICS_CHANNEL_DIM_REQUIRED:
+                metric_kwargs['channel_dim'] = channel_dim
+            empty_metrics.append(metric_type(model, **metric_kwargs))
         super().__init__(
             model=model,
             data=data,
             explainers=explainers,
-            metrics=metrics,
+            postprocessors=all_postprocessors(channel_dim),
+            metrics=empty_metrics,
             modality=modality,
             input_extractor=input_extractor,
             label_extractor=label_extractor,
             target_extractor=target_extractor,
-            input_visualizer=input_visualizer,
-            target_visualizer=target_visualizer,
             target_labels=target_labels,
         )
 
-    
-    # @staticmethod
-    # def recommend(model: Model, question: Question, task: Task) -> RecommenderOutput:
-    #     """
-    #     Recommend explainers and metrics based on the model architecture.
-
-    #     Parameters:
-    #         model (1Model): The machine learning model to recommend explainers for.
-    #         question (Question): The type of question the experiment aims to answer.
-    #         task (Task): The type of task the model is designed for.
-
-    #     Returns:
-    #         RecommenderOutput: Output containing recommended explainers and metrics.
-    #     """
-    #     model_arch = detect_model_architecture(model)
-
-    #     recommender = XaiRecommender()
-    #     recommender_out = recommender(question, task, model_arch)
-
-    #     return recommender_out

--- a/pnpxai/core/experiment/cache.py
+++ b/pnpxai/core/experiment/cache.py
@@ -5,6 +5,8 @@ from pnpxai.utils import to_device
 
 class ExperimentCache:
     __EXPLAINER_KEY = "explainer"
+    __METRIC_KEY = "metric"
+    __POSTPROCESSOR_KEY = "postprocessor"
     __EVALUATION_KEY = "evaluation"
     __DATA_KEY = "data"
 
@@ -27,8 +29,14 @@ class ExperimentCache:
         key = self._get_key(data_id, explainer_id)
         return self._global_cache.get(key, None)
 
-    def get_evaluation(self, data_id: int, explainer_id: int, metric_id: int) -> Optional[Any]:
-        key = self._get_key(data_id, explainer_id, metric_id)
+    def get_evaluation(
+        self,
+        data_id: int,
+        explainer_id: int,
+        postprocessor_id: int,
+        metric_id: int
+    ) -> Optional[Any]:
+        key = self._get_key(data_id, explainer_id, postprocessor_id, metric_id)
         return self._global_cache.get(key, None)
 
     def set_output(self, data_id: int, output: Any):
@@ -39,11 +47,24 @@ class ExperimentCache:
         key = self._get_key(data_id, explainer_id)
         self._global_cache[key] = self.to_device(explanation)
 
-    def set_evaluation(self, data_id: int, explainer_id: int, metric_id: int, evaluation: Any):
-        key = self._get_key(data_id, explainer_id, metric_id)
+    def set_evaluation(
+        self,
+        data_id: int,
+        explainer_id: int,
+        postprocessor_id: int,
+        metric_id: int,
+        evaluation: Any
+    ):
+        key = self._get_key(data_id, explainer_id, postprocessor_id, metric_id)
         self._global_cache[key] = self.to_device(evaluation)
 
-    def _get_key(self, data_id: int, explainer_id: Optional[int] = None, metric_id: Optional[int] = None):
+    def _get_key(
+        self,
+        data_id: int,
+        explainer_id: Optional[int] = None,
+        postprocessor_id: Optional[int] = None,
+        metric_id: Optional[int] = None
+    ):
         key = f"{self.__DATA_KEY}_{data_id}"
         if explainer_id is None:
             return key
@@ -52,4 +73,4 @@ class ExperimentCache:
         if metric_id is None:
             return key
 
-        return f"{key}.{self.__EVALUATION_KEY}_{metric_id}"
+        return f"{key}.{self.__POSTPROCESSOR_KEY}_{postprocessor_id}.{self.__EVALUATION_KEY}_{metric_id}"

--- a/pnpxai/core/experiment/experiment.py
+++ b/pnpxai/core/experiment/experiment.py
@@ -60,6 +60,7 @@ class Experiment(Observable):
         model: Model,
         data: DataSource,
         explainers: Sequence[Explainer],
+        postprocessors: Optional[Sequence[Callable]] = None,
         metrics: Optional[Sequence[Metric]] = None,
         modality: ModalityOrListOfModalities = "image",
         input_extractor: Optional[Callable[[Any], Any]] = None,
@@ -74,12 +75,13 @@ class Experiment(Observable):
         self.model = model
         self.model_device = next(self.model.parameters()).device
 
-        self.manager = ExperimentManager(
-            data=data,
-            explainers=explainers,
-            metrics=metrics or [],
-            cache_device=cache_device,
-        )
+        self.manager = ExperimentManager(data=data, cache_device=cache_device)
+        for explainer in explainers:
+            self.manager.add_explainer(explainer)
+        for postprocessor in postprocessors:
+            self.manager.add_postprocessor(postprocessor)
+        for metric in metrics:
+            self.manager.add_metric(metric)
 
         self.input_extractor = input_extractor \
             if input_extractor is not None \
@@ -103,28 +105,136 @@ class Experiment(Observable):
     def errors(self):
         return self._errors
 
-    @property
-    def all_explainers(self) -> Sequence[Explainer]:
-        return self.manager.all_explainers
+    # @property
+    # def all_explainers(self) -> Sequence[Explainer]:
+    #     return self.manager.all_explainers
 
-    @property
-    def all_metrics(self) -> Sequence[Metric]:
-        return self.manager.all_metrics
+    # @property
+    # def all_metrics(self) -> Sequence[Metric]:
+    #     return self.manager.all_metrics
 
-    def get_current_explainers(self) -> List[Explainer]:
-        return self.manager.get_explainers()[0]
+    # def get_current_explainers(self) -> List[Explainer]:
+    #     return self.manager.get_explainers()[0]
 
-    def get_current_metrics(self) -> List[Metric]:
-        return self.manager.get_metrics()[0]
+    # def get_current_metrics(self) -> List[Metric]:
+    #     return self.manager.get_metrics()[0]
 
     def to_device(self, x):
         return to_device(x, self.model_device)
+
+    def run_batch(
+        self,
+        data_ids: List[int],
+        explainer_id: int,
+        postprocessor_id: int,
+        metric_id: int,
+    ):
+        self.predict_batch(data_ids)
+        self.explain_batch(data_ids, explainer_id)
+        self.evaluate_batch(
+            data_ids, explainer_id, postprocessor_id, metric_id)
+        data = self.manager.batch_data_by_ids(data_ids)
+        return {
+            'inputs': self.input_extractor(data),
+            'labels': self.label_extractor(data),
+            'outputs': self.manager.batch_outputs_by_ids(data_ids),
+            'targets': self._get_targets(data_ids),
+            'explainer': self.manager.get_explainer_by_id(explainer_id),
+            'explanation': self.manager.batch_explanations_by_ids(data_ids, explainer_id),
+            'postprocessor': self.manager.get_postprocessor_by_id(postprocessor_id),
+            'postprocessed': self.postprocess_batch(data_ids, explainer_id, postprocessor_id),
+            'metric': self.manager.get_metric_by_id(metric_id),
+            'evaluation': self.manager.batch_evaluations_by_ids(data_ids, explainer_id, postprocessor_id, metric_id),
+        }
+
+
+    def predict_batch(
+        self,
+        data_ids: List[int],
+    ):
+        data_ids_pred = [
+            idx for idx in data_ids
+            if self.manager.get_output_by_id(idx) is None
+        ]
+        if len(data_ids_pred) > 0:
+            data = self.manager.batch_data_by_ids(data_ids_pred)
+            outputs = self.model(*format_into_tuple(self.input_extractor(data)))
+            self.manager.cache_outputs(data_ids_pred, outputs)
+        return self.manager.batch_outputs_by_ids(data_ids)
+
+    def explain_batch(
+        self,
+        data_ids: List[int],
+        explainer_id: int,
+    ):
+        data_ids_expl = [
+            idx for idx in data_ids
+            if self.manager.get_explanation_by_id(idx, explainer_id) is None
+        ]
+        if len(data_ids_expl):
+            data = self.manager.batch_data_by_ids(data_ids_expl)
+            inputs = self.input_extractor(data)
+            targets = self._get_targets(data_ids_expl)
+            explainer = self.manager.get_explainer_by_id(explainer_id)
+            explanations = explainer.attribute(inputs, targets)
+            self.manager.cache_explanations(
+                explainer_id, data_ids_expl, explanations)
+        return self.manager.batch_explanations_by_ids(data_ids, explainer_id)
+
+    def postprocess_batch(
+        self,
+        data_ids: List[int],
+        explainer_id: int,
+        postprocessor_id: int,
+    ):
+        explanations = self.manager.batch_explanations_by_ids(data_ids, explainer_id)
+        postprocessor = self.manager.get_postprocessor_by_id(postprocessor_id)
+        return postprocessor(explanations)
+
+    def evaluate_batch(
+        self,
+        data_ids: List[int],
+        explainer_id: int,
+        postprocessor_id: int,
+        metric_id: int,
+    ):
+        data_ids_eval = [
+            idx for idx in data_ids
+            if self.manager.get_evaluation_by_id(
+                idx, explainer_id, postprocessor_id, metric_id) is None
+        ]
+        if len(data_ids_eval):
+            data = self.manager.batch_data_by_ids(data_ids_eval)
+            inputs = self.input_extractor(data)
+            targets = self._get_targets(data_ids_eval)
+            postprocessed = self.postprocess_batch(
+                data_ids_eval, explainer_id, postprocessor_id)
+            explainer = self.manager.get_explainer_by_id(explainer_id)
+            metric = self.manager.get_metric_by_id(metric_id)
+            evaluations = metric.set_explainer(explainer).evaluate(
+                inputs, targets, postprocessed)
+            self.manager.cache_evaluations(
+                explainer_id, postprocessor_id, metric_id,
+                data_ids_eval, evaluations
+            )
+        return self.manager.batch_evaluations_by_ids(
+            data_ids, explainer_id, postprocessor_id, metric_id
+        )
+
+
+    def _get_targets(self, data_ids):
+        if self.target_labels:
+            return self.label_extractor(self.manager.batch_data_by_ids(data_ids))
+        outputs = self.manager.batch_outputs_by_ids(data_ids)
+        return self.target_extractor(outputs)
+
 
     def run(
         self,
         data_ids: Optional[Sequence[int]] = None,
         explainer_ids: Optional[Sequence[int]] = None,
-        metrics_ids: Optional[Sequence[int]] = None,
+        postprocessor_ids: Optional[Sequence[int]] = None,
+        metric_ids: Optional[Sequence[int]] = None,
     ) -> 'Experiment':
         """
         Run the experiment by processing data, generating explanations, evaluating with metrics, caching and retrieving the data.
@@ -144,23 +254,29 @@ class Experiment(Observable):
         If not provided, the method processes all available data, explainers, and metrics.
         """
         self.reset_errors()
-        self.manager.set_config(data_ids, explainer_ids, metrics_ids)
+        # self.manager.set_config(data_ids, explainer_ids, metrics_ids)
         
         # inference
-        data, data_ids = self.manager.get_data_to_predict()
+
+        # data_ids is filtered out data indices whose output is saved in cache
+        data, data_ids_pred = self.manager.get_data_to_predict(data_ids)
         outputs = self._predict(data)
-        self.manager.save_outputs(outputs, data, data_ids)
+        self.manager.save_outputs(outputs, data, data_ids_pred)
 
         # explain
-        explainers, explainer_ids = self.manager.get_explainers()
+        explainers, _ = self.manager.get_explainers(explainer_ids)
+        postprocessors, _ = self.manager.get_postprocessors(postprocessor_ids)
+        metrics, _ = self.manager.get_metrics(metric_ids)
 
         for explainer, explainer_id in zip(explainers, explainer_ids):
             explainer_name = class_to_string(explainer)
-            data, data_ids = self.manager.get_data_to_process_for_explainer(
-                explainer_id)
-            explanations = self._explain(data, data_ids, explainer)
+
+            # data_ids is filtered out data indices whose explanation is saved in cache
+            data, data_ids_expl = self.manager.get_data_to_process_for_explainer(
+                explainer_id, data_ids)
+            explanations = self._explain(data, data_ids_expl, explainer)
             self.manager.save_explanations(
-                explanations, data, data_ids, explainer_id
+                explanations, data, data_ids_expl, explainer_id
             )
             message = get_message(
                 'experiment.event.explainer', explainer=explainer_name
@@ -169,24 +285,24 @@ class Experiment(Observable):
             self.fire(ExperimentObservableEvent(
                 self.manager, message, explainer))
 
-            metrics, metric_ids = self.manager.get_metrics()
-            for metric, metric_id in zip(metrics, metric_ids):
-                metric_name = class_to_string(metric)
-                data, data_ids = self.manager.get_data_to_process_for_metric(
-                    explainer_id, metric_id)
-                explanations, data_ids = self.manager.get_valid_explanations(
-                    explainer_id, data_ids)
-                data, _ = self.manager.get_data(data_ids)
-                evaluations = self._evaluate(
-                    data, data_ids, explanations, explainer, metric)
-                self.manager.save_evaluations(
-                    evaluations, data, data_ids, explainer_id, metric_id)
+            for postprocessor, postprocessor_id in zip(postprocessors, postprocessor_ids):
+                for metric, metric_id in zip(metrics, metric_ids):
+                    metric_name = class_to_string(metric)
+                    data, data_ids_eval = self.manager.get_data_to_process_for_metric(
+                        explainer_id, postprocessor_id, metric_id, data_ids)
+                    explanations, data_ids_eval = self.manager.get_valid_explanations(
+                        explainer_id, data_ids_eval)
+                    data, _ = self.manager.get_data(data_ids_eval)
+                    evaluations = self._evaluate(
+                        data, data_ids_eval, explanations, explainer, postprocessor, metric)
+                    self.manager.save_evaluations(
+                        evaluations, data, data_ids_eval, explainer_id, postprocessor_id, metric_id)
 
-                message = get_message(
-                    'experiment.event.explainer.metric', explainer=explainer_name, metric=metric_name)
-                print(f"[Experiment] {message}")
-                self.fire(ExperimentObservableEvent(
-                    self.manager, message, explainer, metric))
+                    message = get_message(
+                        'experiment.event.explainer.metric', explainer=explainer_name, metric=metric_name)
+                    print(f"[Experiment] {message}")
+                    self.fire(ExperimentObservableEvent(
+                        self.manager, message, explainer, metric))
         return self
 
     def _predict(self, data: DataSource):
@@ -220,7 +336,7 @@ class Experiment(Observable):
                 self._errors.append(e)
         return explanations
 
-    def _evaluate(self, data: DataSource, data_ids: List[int], explanations: DataSource, explainer: Explainer, metric: Metric):
+    def _evaluate(self, data: DataSource, data_ids: List[int], explanations: DataSource, explainer: Explainer, postprocessor: Callable, metric: Metric):
         if explanations is None:
             return None
         started_at = time.time()
@@ -237,13 +353,14 @@ class Experiment(Observable):
             targets = self.label_extractor(datum) if self.target_labels \
                 else self._get_targets(data_ids)
             try:
-                # [GH] input args as kwargs to compute metric in an experiment
+                metric = metric.set_explainer(explainer).set_postprocessor(postprocessor)
                 evaluations[i] = metric.evaluate(
                     inputs=inputs,
                     targets=targets,
                     attributions=explanation,
                 )
             except Exception as e:
+                import pdb; pdb.set_trace()
                 warnings.warn(
                     f"\n[Experiment] {get_message('experiment.errors.evaluation', explainer=explainer_name, metric=metric_name, error=e)}")
                 self._errors.append(e)
@@ -341,7 +458,7 @@ class Experiment(Observable):
 
         return visualizations
 
-    def get_inputs_flattened(self) -> Sequence[Tensor]:
+    def get_inputs_flattened(self, data_ids: Optional[List[int]]=None) -> Sequence[Tensor]:
         """
         Retrieve and flatten last run input data.
 
@@ -350,7 +467,7 @@ class Experiment(Observable):
 
         This method retrieves input data using the input extractor and flattens it for further processing.
         """
-        data, _ = self.manager.get_data()
+        data, _ = self.manager.get_data(data_ids)
         data = [self.input_extractor(datum) for datum in data]
         return self.manager.flatten_if_batched(data, data)
 
@@ -367,12 +484,12 @@ class Experiment(Observable):
         data = [self.input_extractor(datum) for datum in data]
         return self.manager.flatten_if_batched(data, data)
 
-    def get_labels_flattened(self) -> Sequence[Tensor]:
-        data, data_ids = self.manager.get_data()
+    def get_labels_flattened(self, data_ids: Optional[List[int]]=None) -> Sequence[Tensor]:
+        data, _ = self.manager.get_data(data_ids)
         labels = [self.label_extractor(datum) for datum in data]
         return self.manager.flatten_if_batched(labels, data)
 
-    def get_targets_flattened(self) -> Sequence[Tensor]:
+    def get_targets_flattened(self, data_ids: Optional[List[int]]=None) -> Sequence[Tensor]:
         """
         Retrieve and flatten target data.
 
@@ -382,15 +499,15 @@ class Experiment(Observable):
         This method retrieves target data using the target extractor and flattens it for further processing.
         """
         if self.target_labels:
-            return self.get_labels_flattened()
-        data, data_ids = self.manager.get_data()
+            return self.get_labels_flattened(data_ids)
+        data, _ = self.manager.get_data(data_ids)
         targets = [self._get_targets(data_ids)]
         return self.manager.flatten_if_batched(targets, data)
         # targets = [self.label_extractor(datum) for datum in data] \
         #     if self.target_labels else [self._get_targets(data_ids)]
         # return self.manager.flatten_if_batched(targets, data)
 
-    def get_outputs_flattened(self) -> Sequence[Tensor]:
+    def get_outputs_flattened(self, data_ids: Optional[List[int]]=None) -> Sequence[Tensor]:
         """
         Retrieve and flatten model outputs.
 
@@ -401,7 +518,7 @@ class Experiment(Observable):
         """
         return self.manager.get_flat_outputs()
 
-    def get_explanations_flattened(self) -> Sequence[Sequence[Tensor]]:
+    def get_explanations_flattened(self, data_ids: Optional[List[int]]=None) -> Sequence[Sequence[Tensor]]:
         """
         Retrieve and flatten explanations from all explainers.
 
@@ -412,11 +529,11 @@ class Experiment(Observable):
         """
         _, explainer_ids = self.manager.get_explainers()
         return [
-            self.manager.get_flat_explanations(explainer_id)
+            self.manager.get_flat_explanations(explainer_id, data_ids)
             for explainer_id in explainer_ids
         ]
 
-    def get_evaluations_flattened(self) -> Sequence[Sequence[Sequence[Tensor]]]:
+    def get_evaluations_flattened(self, data_ids: Optional[List[int]]=None) -> Sequence[Sequence[Sequence[Tensor]]]:
         """
         Retrieve and flatten evaluations for all explainers and metrics.
 
@@ -427,12 +544,15 @@ class Experiment(Observable):
         get_flat_evaluations method.
         """
         _, explainer_ids = self.manager.get_explainers()
+        _, postprocessor_ids = self.manager.get_postprocessors()
         _, metric_ids = self.manager.get_metrics()
 
-        formatted = [[
-            self.manager.get_flat_evaluations(explainer_id, metric_id)
-            for metric_id in metric_ids
-        ] for explainer_id in explainer_ids]
+        formatted = [[[
+                self.manager.get_flat_evaluations(
+                    explainer_id, postprocessor_id, metric_id, data_ids)
+                for metric_id in metric_ids
+            ] for postprocessor_id in postprocessor_ids]
+        for explainer_id in explainer_ids]
 
         return formatted
 
@@ -490,88 +610,65 @@ class Experiment(Observable):
         return self.manager.has_explanations
 
     @property
+    def _records(self):
+        records = []
+        data_ids = [
+            idx for idx, output in enumerate(self.get_outputs_flattened())
+            if output is not None
+        ]
+        _, explainer_ids = self.manager.get_explainers()
+        _, postprocessor_ids = self.manager.get_postprocessors()
+        _, metric_ids = self.manager.get_metrics()
+        return itertools.product(data_ids, explainer_ids, postprocessor_ids, [metric_ids])
+
+    @property
     def records(self):
-        return ExperimentRecords(self)
+        records = []
+        for data_id, explainer_id, postprocessor_id, metric_ids in self._records:
+            explanation = self.manager._cache.get_explanation(data_id, explainer_id)
+            if explanation is None:
+                continue
+            data, _ = self.manager.get_data([data_id])
 
+            inp = self.get_inputs_flattened([data_id])[0]
+            label = self.get_labels_flattened([data_id])[0]
+            output = self.get_outputs_flattened([data_id])[0]
+            target = self.get_targets_flattened([data_id])[0]
 
-class ExperimentRecords:
-    def __init__(self, experiment: Experiment):
-        self.experiment = experiment
-        self._zipped_data = zip(
-            self.experiment.manager.get_data()[-1], # data_id; data_ids[data_loc]
-            self.experiment.get_inputs_flattened(), # input; inputs[data_loc]
-            self.experiment.get_labels_flattened(), # label; labels[data_loc]
-            self.experiment.get_outputs_flattened(), # output; outputs[data_loc]
-            self.experiment.get_targets_flattened(), # target; targets[data_loc]
-            self._rearrange_explanations(),
-            self._rearrange_evaluations(),
-        )
+            postprocessor = self.manager.postprocessors[postprocessor_id]
+            explanation = format_into_tuple(explanation)
+            postprocessor = format_into_tuple(postprocessor)
 
-    def _rearrange_explanations(self):
-        # expls[explainer_loc][data_loc] -> expls[data_loc][explainer_loc]
-        rearranged = []
-        for expl_loc, expl_by_data in enumerate(self.experiment.get_explanations_flattened()):
-            for data_loc, expl in enumerate(expl_by_data):
-                if len(rearranged) < data_loc + 1:
-                    rearranged.append([])
-                if len(rearranged[data_loc]) < expl_loc + 1:
-                    rearranged[data_loc].append([])
-                rearranged[data_loc][expl_loc].append(expl)
-        return rearranged
-
-    def _rearrange_evaluations(self):
-        # evals[explainer_loc][metric_loc][data_loc] -> evals[data_loc][explainer_loc][metric_loc]
-        rearranged = []
-        for expl_loc, eval_by_expl in enumerate(self.experiment.get_evaluations_flattened()):
-            for metric_loc, eval_by_data in enumerate(eval_by_expl):
-                for data_loc, metric in enumerate(eval_by_data):
-                    if len(rearranged) < data_loc + 1:
-                        rearranged.append([])
-                    if len(rearranged[data_loc]) < expl_loc + 1:
-                        rearranged[data_loc].append([])
-                    if len(rearranged[data_loc][expl_loc]) < metric_loc + 1:
-                        rearranged[data_loc][expl_loc].append([])
-                    rearranged[data_loc][expl_loc][metric_loc].append(metric)
-        return rearranged
-
-    @property
-    def explainers(self):
-        return {
-            explainer_id: class_to_string(explainer)
-            for explainer, explainer_id
-            in zip(*self.experiment.manager.get_explainers())
-        }
-
-    @property
-    def metrics(self):
-        return {
-            metric_id: class_to_string(metric)
-            for metric, metric_id
-            in zip(*self.experiment.manager.get_metrics())
-        }
-
-    def __len__(self):
-        return len(self.experiment.manager.get_data()[-1])
-
-    def __getitem__(self, data_loc):
-        row = next(itertools.islice(self._zipped_data, data_loc, None))
-        zipped_explanations = zip(self.explainers.items(), row[5])
-        zipped_evaluations = lambda explainer_loc: zip(self.metrics.items(), row[6][explainer_loc])
-        return {
-            'data_id': row[0],
-            'input': row[1],
-            'label': row[2],
-            'output': row[3],
-            'target': row[4],
-            'explanations': [{
+            postprocessed = []
+            for pp, expl in zip(postprocessor, explanation):
+                channel_dim = pp.channel_dim
+                if channel_dim != -1:
+                    channel_dim -= 1
+                postprocessed.append(pp.copy().set_channel_dim(channel_dim)(expl))
+            postprocessed = format_into_tuple(postprocessed)
+            if len(postprocessed) == 1:
+                postprocessed = postprocessed[0]
+            evaluations = [
+                self.get_evaluations_flattened([data_id])[explainer_id][postprocessor_id][metric_id][0]
+                for metric_id in metric_ids
+            ]
+            records.append({
+                'data_id': data_id,
                 'explainer_id': explainer_id,
-                'explainer_nm': explainer_nm,
-                'value': explanation[0],
+                'postprocessor_id': postprocessor_id,
+                'input': inp,
+                'label': label,
+                'output': output,
+                'target': target,
+                'explainer': self.manager.explainers[explainer_id],
+                'postprocessor': self.manager.postprocessors[postprocessor_id],
+                'explanation': postprocessed,
                 'evaluations': [{
                     'metric_id': metric_id,
-                    'metric_nm': metric_nm,
-                    'value': evaluation[0],
-                } for (metric_id, metric_nm), evaluation in zipped_evaluations(explainer_loc)]
-            } for explainer_loc, ((explainer_id, explainer_nm), explanation) in enumerate(zipped_explanations)]
-        }
-
+                    'metric': metric,
+                    'evaluation': evaluation,
+                } for metric_id, metric, evaluation in zip(
+                    metric_ids, self.manager.metrics, evaluations)
+                ],
+            })
+        return records

--- a/pnpxai/core/experiment/manager.py
+++ b/pnpxai/core/experiment/manager.py
@@ -1,4 +1,6 @@
-from typing import Any, List, Optional, Sequence, Union, Type, Tuple
+from typing import Any, List, Optional, Sequence, Union, Type, Tuple, Callable
+
+import itertools
 
 import torch
 from torch import Tensor
@@ -7,99 +9,277 @@ from torch.utils.data import DataLoader, Subset, Dataset
 from pnpxai.core.experiment.cache import ExperimentCache
 from pnpxai.core._types import DataSource
 from pnpxai.explainers.base import Explainer
+from pnpxai.explainers.utils.postprocess import PostProcessor
 from pnpxai.metrics.base import Metric
-# from pnpxai.explainers._explainer import Explainer, Explainer
-# from pnpxai.evaluator import Metric
+from pnpxai.utils import format_into_tuple
+
+
+def _index_combinations(*indices):
+    return itertools.product(*indices)
 
 
 class ExperimentManager:
     def __init__(
         self,
         data: DataSource,
-        explainers: Sequence[Explainer],
-        metrics: Sequence[Metric],
         cache_device: Optional[Union[torch.device, str]] = None,
     ):
         self._data = data
-        self._metrics = metrics
-        self._explainers = explainers
-        # self._explainers_w_args: List[Explainer] = self.preprocess_explainers(explainers) \
-        #     if explainers is not None \
-        #     else explainers
+        self.set_data_ids()
+        self._explainers: List[Explainer] = []
+        self._explainer_ids: List[int] = []
+        self._postprocessors: List[Callable] =[]
+        self._postprocessor_ids: List[int] = []
+        self._metrics: List[Metric] = []
+        self._metric_ids: List[int] = []
 
         self._cache = ExperimentCache(cache_device)
-        self.set_config()
 
-    # def preprocess_explainers(self, explainers: Sequence[Explainer]) -> List[Explainer]:
-    #     return [
-    #         explainer
-    #         if isinstance(explainer, Explainer)
-    #         else Explainer(explainer)
-    #         for explainer in explainers
-    #     ]
+    def clear(self):
+        self._explainers = []
+        self._explainer_ids = []
+        self._metrics = []
+        self._metric_ids = []
+        self._cache._global_cache = {}
 
-    def set_config(
-        self,
-        data_ids: Optional[Sequence[int]] = None,
-        explainer_ids: Optional[Sequence[int]] = None,
-        metric_ids: Optional[Sequence[int]] = None,
-    ):
-        self.set_data_ids(data_ids)
-        self.set_explainer_ids(explainer_ids)
-        self.set_metric_ids(metric_ids)
+    @property
+    def data(self):
+        return self._data
 
-    def get_data_ids(self) -> Sequence[int]:
-        return self._data_ids
+    @property
+    def explainers(self):
+        return self._explainers
+
+    @property
+    def postprocessors(self):
+        return self._postprocessors
+
+    @property
+    def metrics(self):
+        return self._metrics
 
     def set_data_ids(self, data_ids: Optional[Sequence[int]] = None):
         self._data_ids = data_ids if data_ids is not None else list(
             range(self._all_data_len))
 
-    def set_explainer_ids(self, explainer_ids: Optional[Sequence[int]] = None):
-        self._explainer_ids = explainer_ids if explainer_ids is not None else list(
-            range(len(self._explainers))
-            # range(len(self._explainers_w_args))
-        )
+    def cache_outputs(self, data_ids, outputs):
+        assert len(data_ids) == len(outputs)
+        for idx, output in zip(data_ids, outputs):
+            self._cache.set_output(idx, output)
 
-    def set_metric_ids(self, metric_ids: Optional[Sequence[int]] = None):
-        self._metric_ids = metric_ids if metric_ids is not None else list(
-            range(len(self._metrics))
-        )
+    def cache_explanations(
+        self,
+        explainer_id,
+        data_ids,
+        explanations,
+    ):
+        assert len(explanations) == len(data_ids)
+        for idx, explanation in zip(data_ids, explanations):
+            self._cache.set_explanation(idx, explainer_id, explanation)
 
-    def get_explainers(self) -> Tuple[List[Explainer], List[int]]:
-        return self._get_explainers_by_ids(self._explainer_ids), self._explainer_ids
+    def cache_evaluations(
+        self,
+        explainer_id: int,
+        postprocessor_id: int,
+        metric_id: int,
+        data_ids: List[int],
+        evaluations: DataSource,
+    ):
+        assert len(evaluations) == len(data_ids)
+        for idx, evaluation in zip(data_ids, evaluations):
+            self._cache.set_evaluation(
+                idx, explainer_id, metric_id, postprocessor_id, evaluation)
+
+    def get_data_ids(self) -> Sequence[int]:
+        return self._data_ids
+
+    def _get_data_by_ids(
+        self,
+        data_ids: Optional[Sequence[int]]=None,
+    ) -> List[Any]:
+        if data_ids is None:
+            return self._data
+        if isinstance(self._data, DataLoader):
+            data = self._copy_data_loader(
+                data=Subset(self._data.dataset, data_ids),
+                data_loader=self._data.__class__
+            )
+        elif isinstance(self._data, Dataset):
+            data = Subset(self._data, data_ids)
+        else:
+            try:
+                data = self._data[data_ids]
+            except:
+                data = [self._data[idx] for idx in data_ids]
+        return data
+
+    def get_data(
+        self,
+        data_ids: Optional[Sequence[int]]=None,
+    ) -> Tuple[DataSource, List[int]]:
+        data_ids = data_ids if data_ids is not None else self._data_ids
+        return self._get_data_by_ids(data_ids), data_ids
+
+    ###
+    def get_data_by_id(self, data_id: int):
+        data = self._data.dataset[data_id]
+        data = self._data.collate_fn([data])
+        return tuple(d.squeeze(0) for d in data)
+
+    def get_output_by_id(self, data_id: int):
+        return self._cache.get_output(data_id)
+
+    def get_explainer_by_id(self, explainer_id: int):
+        return self._explainers[explainer_id]
+
+    def get_explanation_by_id(self, data_id: int, explainer_id: int):
+        return self._cache.get_explanation(data_id, explainer_id)
+
+    def get_postprocessor_by_id(self, postprocessor_id: int):
+        return self._postprocessors[postprocessor_id]
+
+    def get_metric_by_id(self, metric_id: int):
+        return self._metrics[metric_id]
+
+    def get_evaluation_by_id(
+        self,
+        data_id: int,
+        explainer_id: int,
+        postprocessor_id: int,
+        metric_id: int
+    ):
+        return self._cache.get_evaluation(
+            data_id, explainer_id, postprocessor_id, metric_id)
+
+    def batch_data_by_ids(
+        self,
+        data_ids: List[int],
+    ):
+        batch = [self._data.dataset[idx] for idx in data_ids]
+        batch = self._data.collate_fn(batch)
+        return batch
+
+    def batch_outputs_by_ids(self, data_ids: List[int]):
+        batch = []
+        for data_id in data_ids:
+            output = self.get_output_by_id(data_id)
+            if output is None:
+                raise KeyError(f"Output for {data} does not exist in cache.")
+            batch.append(output)
+        return self._format_batch(batch)
+
+    def batch_explainers_by_ids(self, explainer_ids: List[int]):
+        return [self._explainers[idx] for idx in explainer_ids]
+
+    def batch_explanations_by_ids(
+        self,
+        data_ids: List[int],
+        explainer_id: int,
+    ):
+        batch = [
+            self.get_explanation_by_id(data_id, explainer_id)
+            for data_id in data_ids
+        ]
+        return self._format_batch(batch)
+
+    def batch_evaluations_by_ids(
+        self,
+        data_ids: List[int],
+        explainer_id: int,
+        postprocessor_id: int,
+        metric_id: int,
+    ):
+        batch = [
+            self.get_evaluation_by_id(
+                data_id, explainer_id, postprocessor_id, metric_id)
+            for data_id in data_ids
+        ]
+        return self._format_batch(batch)
+
+    def _format_batch(self, batch):
+        if torch.is_tensor(batch[0]):
+            return torch.stack(batch)
+        return batch            
+
+    def add_explainer(self, explainer: Explainer) -> int:
+        explainer_id = len(self._explainers)
+        self._explainers.append(explainer)
+        self._explainer_ids.append(explainer_id)
+        return explainer_id
 
     def _get_explainers_by_ids(self, explainer_ids: Optional[Sequence[int]] = None) -> List[Explainer]:
         # return [self._explainers_w_args[idx] for idx in explainer_ids] if explainer_ids is not None else self._explainers_w_args
         return [self._explainers[idx] for idx in explainer_ids] if explainer_ids is not None else self._explainers
 
-    def get_metrics(self) -> Tuple[List[Metric], List[int]]:
-        return self._get_metrics_by_ids(self._metric_ids), self._metric_ids
+    def get_explainers(self, explainer_ids: Optional[List[int]]=None) -> Tuple[List[Explainer], List[int]]:
+        explainer_ids = explainer_ids or self._explainer_ids
+        return self._get_explainers_by_ids(explainer_ids), explainer_ids
+
+    def add_postprocessor(self, postprocessor: Callable) -> int:
+        postprocessor_id = len(self._postprocessors)
+        self._postprocessors.append(postprocessor)
+        self._postprocessor_ids.append(postprocessor_id)
+        return postprocessor_id
+
+    def _get_postprocessors_by_ids(self, postprocessor_ids: Optional[Sequence[int]]=None) -> List[Callable]:
+        return [self._postprocessors[idx] for idx in postprocessor_ids] if postprocessor_ids is not None else self._postprocessors
+
+    def get_postprocessors(self, postprocessor_ids: Optional[List[int]]=None) -> Tuple[List[Callable], List[int]]:
+        postprocessor_ids = postprocessor_ids or self._postprocessor_ids
+        return self._get_postprocessors_by_ids(postprocessor_ids), postprocessor_ids
+
+    # metric
+    def add_metric(self, metric: Metric) -> int:
+        metric_id = len(self._metrics)
+        self._metrics.append(metric)
+        self._metric_ids.append(metric_id)
+        return metric_id
 
     def _get_metrics_by_ids(self, metric_ids: Optional[Sequence[int]] = None) -> List[Metric]:
         return [self._metrics[idx] for idx in metric_ids] if metric_ids is not None else self._metrics
 
-    def get_data_to_process_for_explainer(self, explainer_id: int) -> Tuple[DataSource, List[int]]:
+    def get_metrics(self, metric_ids: Optional[List[int]]=None) -> Tuple[List[Metric], List[int]]:
+        metric_ids = metric_ids or self._metric_ids
+        return self._get_metrics_by_ids(metric_ids), metric_ids
+
+    # explanation
+    def get_data_to_process_for_explainer(
+        self,
+        explainer_id: int,
+        data_ids: Optional[List[int]] = None,
+    ) -> Tuple[DataSource, List[int]]:
+        data_ids = data_ids or self._data_ids
         data_ids = [
-            idx for idx in self._data_ids if self._cache.get_explanation(idx, explainer_id) is None
+            idx for idx in data_ids if self._cache.get_explanation(idx, explainer_id) is None
         ]
         return self._get_data_by_ids(data_ids), data_ids
 
-    def get_data_to_process_for_metric(self, explainer_id: int, metric_id: int) -> Tuple[DataSource, List[int]]:
+    def save_explanations(self, explanations: DataSource, data: DataSource, data_ids: Sequence[int], explainer_id: int):
+        explanations = self.flatten_if_batched(explanations, data)
+        assert len(explanations) == len(data_ids)
+        for idx, explanation in zip(data_ids, explanations):
+            self._cache.set_explanation(idx, explainer_id, explanation)
+
+    def get_data_to_process_for_metric(
+        self,
+        explainer_id: int,
+        postprocessor_id: int,
+        metric_id: int,
+        data_ids: Optional[List[int]]=None,
+    ) -> Tuple[DataSource, List[int]]:
+        data_ids = data_ids or self._data_ids
         data_ids = [
-            idx for idx in self._data_ids if self._cache.get_evaluation(idx, explainer_id, metric_id) is None
+            idx for idx in data_ids
+            if self._cache.get_evaluation(idx, explainer_id, postprocessor_id, metric_id) is None
         ]
         return self._get_data_by_ids(data_ids), data_ids
 
-    def get_data_to_predict(self) -> Tuple[DataSource, List[int]]:
+    def get_data_to_predict(self, data_ids: List[int]) -> Tuple[DataSource, List[int]]:
         data_ids = [
-            idx for idx in self._data_ids if self._cache.get_output(idx) is None
+            idx for idx in data_ids if self._cache.get_output(idx) is None
         ]
         return self._get_data_by_ids(data_ids), data_ids
 
-    def get_data(self, data_ids: Optional[Sequence[int]] = None) -> Tuple[DataSource, List[int]]:
-        data_ids = data_ids if data_ids is not None else self._data_ids
-        return self._get_data_by_ids(data_ids), data_ids
 
     def get_all_data(self) -> DataSource:
         return self._get_data_by_ids()
@@ -125,28 +305,36 @@ class ExperimentManager:
         data_ids = data_ids if data_ids is not None else self._data_ids
         return [self._cache.get_explanation(idx, explainer_id) for idx in data_ids]
 
-    def get_flat_evaluations(self, explainer_id: int, metric_id: int, data_ids: Optional[Sequence[int]] = None) -> Sequence[Tensor]:
+    def get_flat_evaluations(
+        self,
+        explainer_id: int,
+        postprocessor_id: int,
+        metric_id: int,
+        data_ids: Optional[Sequence[int]] = None
+    ) -> Sequence[Tensor]:
         data_ids = data_ids if data_ids is not None else self._data_ids
-        return [self._cache.get_evaluation(idx, explainer_id, metric_id) for idx in data_ids]
+        return [self._cache.get_evaluation(
+            idx, explainer_id, postprocessor_id, metric_id) for idx in data_ids]
 
     def get_flat_outputs(self, data_ids: Optional[Sequence[int]] = None) -> Tuple[DataSource, List[int]]:
         data_ids = data_ids if data_ids is not None else self._data_ids
         return [self._cache.get_output(idx) for idx in data_ids]
 
-    def save_explanations(self, explanations: DataSource, data: DataSource, data_ids: Sequence[int], explainer_id: int):
-        explanations = self.flatten_if_batched(explanations, data)
-        assert len(explanations) == len(data_ids)
-
-        for idx, explanation in zip(data_ids, explanations):
-            self._cache.set_explanation(idx, explainer_id, explanation)
-
-    def save_evaluations(self, evaluations: DataSource, data: DataSource, data_ids: Sequence[int], explainer_id: int, metric_id: int):
+    def save_evaluations(
+        self,
+        evaluations: DataSource,
+        data: DataSource,
+        data_ids: Sequence[int],
+        explainer_id: int,
+        postprocessor_id: int,
+        metric_id: int
+    ):
         evaluations = self.flatten_if_batched(evaluations, data)
         assert len(evaluations) == len(data_ids)
 
         for idx, evaluation in zip(data_ids, evaluations):
             self._cache.set_evaluation(
-                idx, explainer_id, metric_id, evaluation)
+                idx, explainer_id, metric_id, postprocessor_id, evaluation)
 
     def save_outputs(self, outputs: DataSource, data: DataSource, data_ids: Sequence[int]):
         outputs = self.flatten_if_batched(outputs, data)
@@ -154,6 +342,7 @@ class ExperimentManager:
 
         for idx, output in zip(data_ids, outputs):
             self._cache.set_output(idx, output)
+
 
     def _get_batch_size(self, data: DataSource) -> Optional[int]:
         if torch.is_tensor(data):
@@ -179,24 +368,6 @@ class ExperimentManager:
                 batch = zip(*[list(b) for b in batch])
             flattened.extend(list(batch))
         return flattened
-
-    def _get_data_by_ids(self, data_ids: Optional[Sequence[int]] = None) -> List[Any]:
-        if data_ids is None:
-            return self._data
-        if isinstance(self._data, DataLoader):
-            data = self._copy_data_loader(
-                data=Subset(self._data.dataset, data_ids),
-                data_loader=self._data.__class__
-            )
-        elif isinstance(self._data, Dataset):
-            data = Subset(self._data, data_ids)
-        else:
-            try:
-                data = self._data[data_ids]
-            except:
-                data = [self._data[idx] for idx in data_ids]
-
-        return data
 
     def _copy_data_loader(self, data: DataSource, data_loader: Type[DataLoader], do_collate=True):
         duplicated_params = [

--- a/pnpxai/core/recommender/recommender.py
+++ b/pnpxai/core/recommender/recommender.py
@@ -34,6 +34,10 @@ from pnpxai.metrics import (
     MuFidelity,
     Sensitivity,
     Complexity,
+    MoRF,
+    LeRF,
+    AbPC,
+    AVAILABLE_METRICS,
 )
 
 from ._types import (
@@ -116,9 +120,6 @@ DEFAULT_METRIC_MAP = {
         'modalities': ['image'],
     }
 }
-
-
-AVAILABLE_METRICS = {MuFidelity, Sensitivity, Complexity}
 
 CAM_BASED_EXPLAINERS = {GradCam, GuidedGradCam}
 

--- a/pnpxai/explainers/__init__.py
+++ b/pnpxai/explainers/__init__.py
@@ -59,3 +59,5 @@ AVAILABLE_EXPLAINERS = [
     TransformerAttribution,
 ]
 
+EXPLAINERS_FOR_TABULAR = []
+

--- a/pnpxai/explainers/grad_cam.py
+++ b/pnpxai/explainers/grad_cam.py
@@ -3,6 +3,7 @@ from captum.attr import LayerGradCam, LayerAttribution
 
 from .base import Explainer
 from .utils import find_cam_target_layer
+from pnpxai.utils import format_into_tuple
 
 
 class GradCam(Explainer):
@@ -17,6 +18,8 @@ class GradCam(Explainer):
 
     def attribute(self, inputs: Tensor, targets: Tensor) -> Tensor:
         forward_args, additional_forward_args = self._extract_forward_args(inputs)
+        forward_args = format_into_tuple(forward_args)
+        additional_forward_args = format_into_tuple(additional_forward_args)
         assert len(forward_args) == 1, 'GradCam for multiple inputs is not supported yet.'
         layer = find_cam_target_layer(self.model)
         explainer = LayerGradCam(forward_func=self.model, layer=layer)

--- a/pnpxai/explainers/guided_grad_cam.py
+++ b/pnpxai/explainers/guided_grad_cam.py
@@ -4,6 +4,7 @@ from captum.attr import GuidedGradCam as CaptumGuidedGradCam
 
 from .base import Explainer
 from .utils import find_cam_target_layer
+from pnpxai.utils import format_into_tuple
 
 
 class GuidedGradCam(Explainer):
@@ -18,6 +19,8 @@ class GuidedGradCam(Explainer):
     
     def attribute(self, inputs: Tensor, targets: Tensor) -> Tensor:
         forward_args, additional_forward_args = self._extract_forward_args(inputs)
+        forward_args = format_into_tuple(forward_args)
+        additional_forward_args = format_into_tuple(additional_forward_args)
         assert len(forward_args) == 1, 'GuidedGradCam for multiple inputs is not supported yet.'
         layer = find_cam_target_layer(self.model)
         explainer = CaptumGuidedGradCam(model=self.model, layer=layer)

--- a/pnpxai/explainers/utils/postprocess.py
+++ b/pnpxai/explainers/utils/postprocess.py
@@ -1,34 +1,105 @@
+import math
 from torch import Tensor
 
 RELEVANCE_POOLING_METHODS = {
-    'sumpos': lambda attr, channel_dim: attr.sum(channel_dim).clamp(min=0),
-    'sumabs': lambda attr, channel_dim: attr.sum(channel_dim).abs(),
-    'l1norm': lambda attr, channel_dim: attr.abs().sum(channel_dim),
-    'maxnorm': lambda attr, channel_dim: attr.abs().max(channel_dim)[0],
-    'l2norm': lambda attr, channel_dim: attr.pow(2).sum(channel_dim).sqrt(),
-    'l2normsq': lambda attr, channel_dim: attr.pow(2).sum(channel_dim),
-    'possum': lambda attr, channel_dim: attr.clamp(min=0).sum(channel_dim),
-    'posmaxnorm': lambda attr, channel_dim: attr.clamp(min=0).max(channel_dim)[0],
-    'posl2norm': lambda attr, channel_dim: attr.clamp(min=0).pow(2).sum(channel_dim).sqrt(),
-    'posl2normsq': lambda attr, channel_dim: attr.clamp(min=0).pow(2).sum(channel_dim),
+    'sumpos': lambda attrs, channel_dim: attrs.sum(channel_dim).clamp(min=0),
+    'sumabs': lambda attrs, channel_dim: attrs.sum(channel_dim).abs(),
+    'l1norm': lambda attrs, channel_dim: attrs.abs().sum(channel_dim),
+    'maxnorm': lambda attrs, channel_dim: attrs.abs().max(channel_dim)[0],
+    'l2norm': lambda attrs, channel_dim: attrs.pow(2).sum(channel_dim).sqrt(),
+    'l2normsq': lambda attrs, channel_dim: attrs.pow(2).sum(channel_dim),
+    'possum': lambda attrs, channel_dim: attrs.clamp(min=0).sum(channel_dim),
+    'posmaxnorm': lambda attrs, channel_dim: attrs.clamp(min=0).max(channel_dim)[0],
+    'posl2norm': lambda attrs, channel_dim: attrs.clamp(min=0).pow(2).sum(channel_dim).sqrt(),
+    'posl2normsq': lambda attrs, channel_dim: attrs.clamp(min=0).pow(2).sum(channel_dim),
 }
 
-def relevance_pooling(attr: Tensor, channel_dim: int, method='sumpos'):
-    return RELEVANCE_POOLING_METHODS[method](attr, channel_dim)
+
+def relevance_pooling(attrs: Tensor, channel_dim: int, method='l2normsq'):
+    return RELEVANCE_POOLING_METHODS[method](attrs, channel_dim)
+
+
+def minmax_normalization(attrs: Tensor):
+    bsz, *size = attrs.size()
+    attrs_min = attrs.view(-1, math.prod(size)).min(axis=1).values
+    attrs_min = attrs_min[(...,)+(None,)*len(size)]
+    attrs_max = attrs.view(-1, math.prod(size)).max(axis=1).values
+    attrs_max = attrs_max[(...,)+(None,)*len(size)]
+    return (attrs - attrs_min) / (attrs_max - attrs_min)
+
 
 RELEVANCE_NORMALIZATION_METHODS = {
-    'minmax': lambda attr: (attr - attr.min()) / (attr.max() - attr.min())
+    'minmax': minmax_normalization,
 }
+
 
 def normalize_relevance(pooled_attr: Tensor, method='minmax'):
     return RELEVANCE_NORMALIZATION_METHODS[method](pooled_attr)
 
+
 def postprocess_attr(
     attr: Tensor,
     channel_dim: int,
-    pooling_method: str = 'sumpos',
+    pooling_method: str = 'l2normsq',
     normalization_method: str = 'minmax',
 ):
     pooled_attr = relevance_pooling(attr, channel_dim, method=pooling_method)
     normalized_attr = normalize_relevance(pooled_attr, method=normalization_method)
     return normalized_attr
+
+
+class PostProcessor:
+    def __init__(
+        self,
+        pooling_method='l2normsq',
+        normalization_method='minmax',
+        channel_dim=-1,
+    ):
+        self.pooling_method = pooling_method
+        self.normalization_method = normalization_method
+        self.channel_dim = channel_dim
+
+    def __repr__(self):
+        return f"PostProcessor(pooling_method='{self.pooling_method}', normalization_method='{self.normalization_method}', channel_dim={self.channel_dim})"
+
+    def set_channel_dim(self, channel_dim: int):
+        self.channel_dim = channel_dim
+        return self
+
+    def pool_attributions(self, attrs):
+        return relevance_pooling(attrs, channel_dim=self.channel_dim, method=self.pooling_method)
+
+    def normalize_attributions(self, attrs):
+        return normalize_relevance(attrs, method=self.normalization_method)
+
+    def __call__(self, attrs):
+        return postprocess_attr(
+            attrs,
+            channel_dim=self.channel_dim,
+            pooling_method=self.pooling_method,
+            normalization_method=self.normalization_method
+        )
+
+    def copy(self):
+        return PostProcessor(
+            pooling_method=self.pooling_method,
+            normalization_method=self.normalization_method,
+            channel_dim=self.channel_dim,
+        )
+
+
+def all_postprocessors(channel_dim):
+    if isinstance(channel_dim, int):
+        return [PostProcessor(
+            pooling_method=pm,
+            normalization_method=nm,
+            channel_dim=channel_dim
+        ) for pm in RELEVANCE_POOLING_METHODS
+        for nm in RELEVANCE_NORMALIZATION_METHODS]
+    return [tuple(
+        PostProcessor(
+            pooling_method=pm,
+            normalization_method=nm,
+            channel_dim=channel_dim[d]
+        ) for d in channel_dim
+    ) for pm in RELEVANCE_POOLING_METHODS for nm in RELEVANCE_NORMALIZATION_METHODS]

--- a/pnpxai/metrics/__init__.py
+++ b/pnpxai/metrics/__init__.py
@@ -1,9 +1,18 @@
 from .mu_fidelity import MuFidelity
 from .sensitivity import Sensitivity
 from .complexity import Complexity
+from .pixel_flipping import (
+    PixelFlipping,
+    MoRF,
+    LeRF,
+    AbPC,
+)
 
-AVAILABLE_METRICS = [
-    MuFidelity,
-    Sensitivity,
-    Complexity,
+
+PIXEL_FLIPPING_METRICS = [
+    MoRF,
+    LeRF,
+    AbPC,
 ]
+
+AVAILABLE_METRICS = PIXEL_FLIPPING_METRICS

--- a/pnpxai/metrics/base.py
+++ b/pnpxai/metrics/base.py
@@ -1,13 +1,15 @@
 import abc
 import sys
 import warnings
-from typing import Optional, Union, Callable
+from typing import Optional, Union, Callable, Tuple
 
 import torch
 from torch import nn
 
 from pnpxai.core._types import ExplanationType
+from pnpxai.explainers import GradCam
 from pnpxai.explainers.base import Explainer
+from pnpxai.explainers.utils.postprocess import PostProcessor
 
 # Ensure compatibility with Python 2/3
 ABC = abc.ABC if sys.version_info >= (3, 4) else abc.ABCMeta(str('ABC'), (), {})
@@ -17,16 +19,17 @@ class Metric(ABC):
     SUPPORTED_EXPLANATION_TYPE: ExplanationType = "attribution"
 
     def __init__(
-            self,
-            model: nn.Module,
-            explainer: Optional[Explainer] = None,
-            **kwargs
-        ):
+        self,
+        model: nn.Module,
+        explainer: Optional[Explainer]=None,
+        **kwargs
+    ):
         self.model = model.eval()
         self.explainer = explainer
         self.device = next(model.parameters()).device
 
-    def set_explainer(self, exlainer: Explainer):
+    def set_explainer(self, explainer: Explainer):
+        assert self.model is explainer.model, 'Must have same model of metric.'
         self.explainer = explainer
         return self
 

--- a/pnpxai/metrics/pixel_flipping.py
+++ b/pnpxai/metrics/pixel_flipping.py
@@ -1,0 +1,408 @@
+from typing import Callable, Optional, Union, Tuple, Dict, Any
+
+import torch
+import torch.nn.functional as F
+from torch.nn.modules import Module
+
+from pnpxai.explainers.types import Tensor, TensorOrTupleOfTensors
+from pnpxai.explainers.base import Explainer
+from pnpxai.explainers import GradCam
+from pnpxai.metrics.base import Metric
+from pnpxai.utils import format_into_tuple, format_into_tuple_all
+from pnpxai.explainers.utils.postprocess import PostProcessor
+
+
+BaselineFunction = Union[Callable[[Tensor], Tensor], Tuple[Callable[[Tensor], Tensor]]]
+
+class PixelFlipping(Metric):
+    """
+    A metric class for evaluating the correctness of explanations or attributions provided by an explainer 
+    using the pixel flipping technique.
+
+    This class assesses the quality of attributions by perturbing input features (e.g., pixels) in the order 
+    of their attributed importance and measuring the resulting change in the model's predictions. Correct attributions 
+    should lead to significant changes in model predictions when the most important features are perturbed.
+
+    Attributes:
+        model (Module): The model.
+        explainer (Optional[Explainer]=None): The explainer whose explanations are being evaluated.
+        postprocessor (Optional[Union[PostProcessor, Tuple[PostProcessor]]]): Post-processing steps for attributions.
+        n_steps (int): The number of perturbation steps.
+        baseline_fn (Optional[BaselineFunction]): Function to generate baseline inputs for perturbation.
+        prob_fn (Optional[Callable[[Tensor], Tensor]]): Function to compute probabilities from model outputs.
+        pred_fn (Optional[Callable[[Tensor], Tensor]]): Function to compute predictions from model outputs.
+    
+    Methods:
+        evaluate(inputs, targets, attributions, attention_mask=None, descending=True):
+            Evaluate the explainer's correctness based on the attributions by observing changes in model predictions.
+    """
+
+    def __init__(
+        self,
+        model: Module,
+        explainer: Optional[Explainer]=None,
+        channel_dim: int=1,
+        n_steps: int=10,
+        baseline_fn: Optional[BaselineFunction]=None,
+        prob_fn: Optional[Callable[[Tensor], Tensor]]=lambda outputs: outputs.softmax(-1),
+        pred_fn: Optional[Callable[[Tensor], Tensor]]=lambda outputs: outputs.argmax(-1),
+    ):
+        super().__init__(model, explainer)
+        self.channel_dim = channel_dim
+        self.n_steps = n_steps
+        self.baseline_fn = baseline_fn
+        self.prob_fn = prob_fn
+        self.pred_fn = pred_fn
+
+    @torch.no_grad()
+    def evaluate(
+        self,
+        inputs: TensorOrTupleOfTensors,
+        targets: Tensor,
+        attributions: TensorOrTupleOfTensors,
+        attention_mask: Optional[TensorOrTupleOfTensors]=None,
+        descending: bool=True,
+    ) -> Union[Dict[str, Tensor], Tuple[Dict[str, Tensor]]]:
+        """
+        Evaluate the explainer's correctness based on the attributions by observing changes in model predictions.
+
+        Args:
+            inputs (TensorOrTupleOfTensors): The input tensors to the model.
+            targets (Tensor): The target labels for the inputs.
+            attributions (TensorOrTupleOfTensors): The attributions for the inputs.
+            attention_mask (Optional[TensorOrTupleOfTensors], optional): Attention masks for the inputs. Default is None.
+            descending (bool, optional): Whether to flip pixels in descending order of attribution. Default is True.
+
+        Returns:
+            Union[Dict[str, Tensor], Tuple[Dict[str, Tensor]]]: A dictionary or tuple of dictionaries containing
+                the probabilities and predictions at each perturbation step.
+        """
+        forward_args, additional_forward_args = self.explainer._extract_forward_args(inputs)
+        formatted: Dict[str, Tuple[Any]] = format_into_tuple_all(
+            forward_args=forward_args,
+            additional_forward_args=additional_forward_args,
+            attributions=attributions,
+            baseline_fn=self.baseline_fn,
+            attention_mask=attention_mask or (None,)*len(format_into_tuple(forward_args)),
+        )
+        assert all(
+            len(formatted['forward_args']) == len(formatted[k]) for k in formatted
+            if k != 'additional_forward_args'
+        )
+
+        bsz = formatted['forward_args'][0].size(0)
+        results = []
+
+        outputs = self.model(
+            *formatted['forward_args'],
+            *formatted['additional_forward_args'],
+        )
+        init_probs = self.prob_fn(outputs)
+        init_preds = self.pred_fn(outputs)
+
+        for pos, forward_arg in enumerate(formatted['forward_args']):
+            baseline_fn = formatted['baseline_fn'][pos]
+            attrs = formatted['attributions'][pos]
+            attrs, original_size = _flatten_if_not_1d(attrs)
+            if formatted['attention_mask'][pos] is not None:
+                attn_mask, _ = _flatten_if_not_1d(formatted['attention_mask'][pos])
+                mask_value = -torch.inf if descending else torch.inf
+                attrs = torch.where(attn_mask == 1, attrs, mask_value)
+
+            valid_n_features = (~attrs.isinf()).sum(-1)
+            n_flipped_per_step = valid_n_features // self.n_steps
+            sorted_indices = torch.argsort(
+                attrs,
+                descending=descending,
+                stable=True,
+            )
+            probs = [_extract_target_probs(init_probs, targets)]
+            preds = [init_preds]
+            for step in range(1, self.n_steps):
+                n_flipped = n_flipped_per_step * step
+                if step + 1 == self.n_steps:
+                    n_flipped = valid_n_features
+
+                is_index_of_flipped = (
+                    F.one_hot(n_flipped-1, num_classes=attrs.size(-1)).to(self.device)
+                    .flip(-1).cumsum(-1).flip(-1)
+                )
+
+                is_flipped = _sort_by_order(is_index_of_flipped, sorted_indices.argsort(-1))
+                is_flipped = _recover_shape_if_flattened(is_flipped, original_size)
+                is_flipped = _match_channel_dim_if_pooled(
+                    is_flipped,
+                    self.channel_dim,
+                    forward_arg.size()
+                )
+
+                baseline = baseline_fn(forward_arg)
+                flipped_forward_arg = baseline * is_flipped + forward_arg * (1 - is_flipped)
+
+                flipped_forward_args = tuple(
+                    flipped_forward_arg if i == pos else formatted['forward_args'][i]
+                    for i in range(len(formatted['forward_args']))
+                )
+                flipped_outputs = self.model(
+                    *flipped_forward_args,
+                    *formatted['additional_forward_args'],
+                )
+                probs.append(_extract_target_probs(self.prob_fn(flipped_outputs), targets))
+                preds.append(self.pred_fn(flipped_outputs))
+            results.append({
+                'probs': torch.stack(probs).transpose(1, 0),
+                'preds': torch.stack(preds).transpose(1, 0),
+            })
+        if len(results) == 1:
+            return results[0]
+        return tuple(results)
+
+
+class MoRF(PixelFlipping):
+    """
+    A metric class for evaluating the correctness of explanations or attributions using the 
+    Most Relevant First (MoRF) pixel flipping technique.
+
+    This class inherits from the PixelFlipping class and evaluates the quality of attributions by perturbing input 
+    features (e.g., pixels) in descending order of their attributed importance. The average probability change is 
+    measured to assess the explainer's correctness (lower better).
+
+    Attributes:
+        model (Module): The model.
+        explainer (Optional[Explainer]=None): The explainer whose explanations are being evaluated.
+        postprocessor (PostProcessor): Post-processing steps for attributions.
+        n_steps (int): The number of perturbation steps.
+        baseline_fn (Optional[BaselineFunction]): Function to generate baseline inputs for perturbation.
+        prob_fn (Optional[Callable[[Tensor], Tensor]]): Function to compute probabilities from model outputs.
+        pred_fn (Optional[Callable[[Tensor], Tensor]]): Function to compute predictions from model outputs.
+    
+    Methods:
+        evaluate(inputs, targets, attributions, attention_mask=None):
+            Evaluate the explainer's correctness using the MoRF technique by observing changes in model predictions.
+    """
+
+    def __init__(
+        self,
+        model: Module,
+        explainer: Optional[Explainer]=None,
+        channel_dim: int=1,
+        n_steps: int=10,
+        baseline_fn: Optional[BaselineFunction]=None,
+        prob_fn: Optional[Callable[[Tensor], Tensor]]=lambda outputs: outputs.softmax(-1),
+        pred_fn: Optional[Callable[[Tensor], Tensor]]=lambda outputs: outputs.argmax(-1),
+    ):
+        super().__init__(
+            model, explainer, channel_dim, n_steps,
+            baseline_fn, prob_fn, pred_fn,
+        )
+
+    def evaluate(
+        self,
+        inputs: TensorOrTupleOfTensors,
+        targets: Tensor,
+        attributions: TensorOrTupleOfTensors,
+        attention_mask: Optional[TensorOrTupleOfTensors]=None
+    ) -> TensorOrTupleOfTensors:
+        """
+        Evaluate the explainer's correctness using the MoRF technique by observing changes in model predictions.
+
+        Args:
+            inputs (TensorOrTupleOfTensors): The input tensors to the model.
+            targets (Tensor): The target labels for the inputs.
+            attributions (TensorOrTupleOfTensors): The attributions for the inputs.
+            attention_mask (Optional[TensorOrTupleOfTensors], optional): Attention masks for the inputs. Default is None.
+
+        Returns:
+            TensorOrTupleOfTensors: The mean probabilities at each perturbation step, indicating the impact of 
+                perturbing the most relevant features first.
+        """
+        pf_results = super().evaluate(inputs, targets, attributions, attention_mask, True)
+        pf_results = format_into_tuple(pf_results)
+        morf = tuple(result['probs'].mean(-1) for result in pf_results)
+        if len(morf) == 1:
+            morf = morf[0]
+        return morf
+
+
+
+class LeRF(PixelFlipping):
+    """
+    A metric class for evaluating the correctness of explanations or attributions using the 
+    Least Relevant First (LeRF) pixel flipping technique.
+
+    This class inherits from the PixelFlipping class and evaluates the quality of attributions by perturbing input 
+    features (e.g., pixels) in ascending order of their attributed importance. The average probability change is 
+    measured to assess the explainer's correctness.
+
+    Attributes:
+        model (Module): The model.
+        explainer (Optional[Explainer]=None): The explainer whose explanations are being evaluated.
+        postprocessor (PostProcessor): Post-processing steps for attributions.
+        n_steps (int): The number of perturbation steps.
+        baseline_fn (Optional[BaselineFunction]): Function to generate baseline inputs for perturbation.
+        prob_fn (Optional[Callable[[Tensor], Tensor]]): Function to compute probabilities from model outputs.
+        pred_fn (Optional[Callable[[Tensor], Tensor]]): Function to compute predictions from model outputs.
+    
+    Methods:
+        evaluate(inputs, targets, attributions, attention_mask=None):
+            Evaluate the explainer's correctness using the LeRF technique by observing changes in model predictions.
+    """
+
+    def __init__(
+        self,
+        model: Module,
+        explainer: Optional[Explainer]=None,
+        channel_dim: int=1,
+        n_steps: int=10,
+        baseline_fn: Optional[BaselineFunction]=None,
+        prob_fn: Optional[Callable[[Tensor], Tensor]]=lambda outputs: outputs.softmax(-1),
+        pred_fn: Optional[Callable[[Tensor], Tensor]]=lambda outputs: outputs.argmax(-1),
+    ):
+        super().__init__(
+            model, explainer, channel_dim, n_steps,
+            baseline_fn, prob_fn, pred_fn,
+        )
+
+    def evaluate(
+        self,
+        inputs: TensorOrTupleOfTensors,
+        targets: Tensor,
+        attributions: TensorOrTupleOfTensors,
+        attention_mask: TensorOrTupleOfTensors=None,
+    ) -> TensorOrTupleOfTensors:
+        """
+        Evaluate the explainer's correctness using the LeRF technique by observing changes in model predictions.
+
+        Args:
+            inputs (TensorOrTupleOfTensors): The input tensors to the model.
+            targets (Tensor): The target labels for the inputs.
+            attributions (TensorOrTupleOfTensors): The attributions for the inputs.
+            attention_mask (Optional[TensorOrTupleOfTensors], optional): Attention masks for the inputs. Default is None.
+
+        Returns:
+            TensorOrTupleOfTensors: The mean probabilities at each perturbation step, indicating the impact of 
+                perturbing the least relevant features first.
+        """
+        pf_results = super().evaluate(inputs, targets, attributions, attention_mask, False)
+        pf_results = format_into_tuple(pf_results)
+        lerf = tuple(result['probs'].mean(-1) for result in pf_results)
+        if len(lerf) == 1:
+            lerf = lerf[0]
+        return lerf
+
+
+
+class AbPC(PixelFlipping):
+    """
+    A metric class for evaluating the correctness of explanations or attributions using the 
+    Area between Perturbation Curves (AbPC) technique.
+
+    This class inherits from the PixelFlipping class and assesses the quality of attributions by comparing 
+    the area between the perturbation curves obtained by perturbing input features (e.g., pixels) in both 
+    ascending and descending order of their attributed importance. The average probability change is 
+    measured, providing a comprehensive evaluation of the explainer's correctness.
+
+    Attributes:
+        model (Module): The model.
+        explainer (Optional[Explainer]=None): The explainer whose explanations are being evaluated.
+        postprocessor (Optional[Union[PostProcessor, Tuple[PostProcessor]]]=None): Post-processing steps for attributions.
+        n_steps (int): The number of perturbation steps.
+        baseline_fn (Optional[BaselineFunction]): Function to generate baseline inputs for perturbation.
+        prob_fn (Optional[Callable[[Tensor], Tensor]]): Function to compute probabilities from model outputs.
+        pred_fn (Optional[Callable[[Tensor], Tensor]]): Function to compute predictions from model outputs.
+        lb (float): The lower bound for clamping the probability differences.
+    
+    Methods:
+        evaluate(inputs, targets, attributions, attention_mask=None):
+            Evaluate the explainer's correctness using the AbPC technique by observing changes in model predictions.
+    """
+
+    def __init__(
+        self,
+        model: Module,
+        explainer: Optional[Explainer]=None,
+        channel_dim: int=1,
+        n_steps: int=10,
+        baseline_fn: Optional[BaselineFunction]=None,
+        prob_fn: Optional[Callable[[Tensor], Tensor]]=lambda outputs: outputs.softmax(-1),
+        pred_fn: Optional[Callable[[Tensor], Tensor]]=lambda outputs: outputs.argmax(-1),
+        lb: float=-1.,
+    ):
+        super().__init__(
+            model, explainer, channel_dim, n_steps,
+            baseline_fn, prob_fn, pred_fn,
+        )
+        self.lb = lb
+
+    def evaluate(
+        self,
+        inputs: TensorOrTupleOfTensors,
+        targets: Tensor,
+        attributions: TensorOrTupleOfTensors,
+        attention_mask: Optional[TensorOrTupleOfTensors]=None,
+        return_pf=False,
+    ) -> TensorOrTupleOfTensors:
+        """
+        Evaluate the explainer's correctness using the AbPC technique by observing changes in model predictions.
+
+        Args:
+            inputs (TensorOrTupleOfTensors): The input tensors to the model.
+            targets (Tensor): The target labels for the inputs.
+            attributions (TensorOrTupleOfTensors): The attributions for the inputs.
+            attention_mask (Optional[TensorOrTupleOfTensors], optional): Attention masks for the inputs. Default is None.
+
+        Returns:
+            TensorOrTupleOfTensors: The mean clamped differences in probabilities at each perturbation step, 
+                indicating the impact of perturbing the most and least relevant features.
+        """
+        # pf by ascending order: lerf
+        pf_ascs = super().evaluate(inputs, targets, attributions, attention_mask, False)
+        pf_ascs = format_into_tuple(pf_ascs)
+
+        # pf by descending order: morf
+        pf_descs = super().evaluate(inputs, targets, attributions, attention_mask, True)
+        pf_descs = format_into_tuple(pf_descs)
+
+        # abpc
+        results = []
+        for pf_asc, pf_desc in zip(pf_ascs, pf_descs):
+            result = (pf_asc['probs'] - pf_desc['probs']).clamp(min=self.lb).mean(-1)
+            if return_pf:
+                result = tuple([result, pf_desc, pf_asc])
+            results.append(result)
+        if len(results) == 1:
+            return results[0]
+        return tuple(results)
+
+
+def _extract_target_probs(probs, targets):
+    # please ensure probs.size() == (batch_size, n_classes)
+    return probs[torch.arange(probs.size(0)), targets]
+
+def _sort_by_order(x, permutation):
+    d1, d2 = x.size()
+    ret = x[
+        torch.arange(d1).unsqueeze(1).repeat((1, d2)).flatten(),
+        permutation.flatten().to(x.device)
+    ].view(d1, d2)
+    return ret
+
+def _flatten_if_not_1d(batch):
+    if batch.dim() > 2:
+        original_size = batch.size()
+        return batch.flatten(1), original_size
+    return batch, batch.size()
+
+def _recover_shape_if_flattened(batch, original_size):
+    if batch.size() == original_size:
+        return batch
+    return batch.view(*original_size)
+
+def _match_channel_dim_if_pooled(batch, channel_dim, x_batch_size):
+    if batch.size() == x_batch_size:
+        return batch
+    n_channels = x_batch_size[channel_dim]
+    n_repeats = tuple(n_channels if d == channel_dim else 1 for d in range(len(x_batch_size)))
+    return batch.unsqueeze(channel_dim).repeat(*n_repeats)
+
+

--- a/pnpxai/metrics/utils.py
+++ b/pnpxai/metrics/utils.py
@@ -1,0 +1,7 @@
+def get_default_channel_dim(modality):
+    if modality == 'image':
+        return 1
+    elif modality == 'text':
+        return -1
+    elif modality == ('image', 'text'):
+        return tuple(get_default_channel_dim(m) for m in modality)

--- a/pnpxai/utils.py
+++ b/pnpxai/utils.py
@@ -104,4 +104,10 @@ def linear_from_params(weight: Tensor, bias: Optional[Tensor] = None) -> nn.Line
 def format_into_tuple(obj: Any):
     if isinstance(obj, Sequence) and not isinstance(obj, str):
         return tuple(obj)
+    elif isinstance(obj, type(None)):
+        return ()
     return (obj,)
+
+
+def format_into_tuple_all(**kwargs):
+    return {k: format_into_tuple(v) for k, v in kwargs.items()}

--- a/tutorials/gradio_auto_expr_imagenet_example.py
+++ b/tutorials/gradio_auto_expr_imagenet_example.py
@@ -1,0 +1,231 @@
+import torch
+
+#------------------------------------------------------------------------------#
+#----------------------------------- setup ------------------------------------#
+#------------------------------------------------------------------------------#
+
+from helpers import load_model_and_dataloader_for_tutorial
+
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+model, loader = load_model_and_dataloader_for_tutorial('image', device)
+
+
+#------------------------------------------------------------------------------#
+#---------------------------- auto experiment ---------------------------------#
+#------------------------------------------------------------------------------#
+
+from pnpxai import AutoExperiment
+
+expr = AutoExperiment(
+    model=model,
+    data=loader,
+    modality='image',
+    question='why',
+    evaluator_enabled=True,
+    input_extractor=lambda batch: batch[0].to(device),
+    label_extractor=lambda batch: batch[1].to(device),
+    target_extractor=lambda outputs: outputs.argmax(-1).to(device),
+    channel_dim=1,
+)
+
+# run_batch returns a dict of results
+results = expr.run_batch(data_ids=[0, 1], explainer_id=1, postprocessor_id=0, metric_id=1)
+
+# Also, we can use experiment manager to browse results as follows
+# get data
+data = expr.manager.get_data_by_id(0) # a pair of single instance (input, label)
+batch = expr.manager.batch_data_by_ids(data_ids=[0, 1]) # a batch of multiple instances (inputs, labels)
+
+# get explainer
+explainer = expr.manager.get_explainer_by_id(0)
+
+# get explanation
+attr = expr.manager.get_explanation_by_id(data_id=0, explainer_id=0)
+batched_attrs = expr.manager.batch_explanations_by_ids(data_ids=[0,1], explainer_id) # batched explanations
+
+# get postprocessor
+postprocessor = expr.manager.get_postprocessor_by_id(0)
+
+# postprocess
+postprocessed = postprocessor(batched_attrs) # Note that this work only for batched attrs
+
+# get metric
+metric = expr.manager.get_metric_by_id(0)
+
+# get evaluation
+evaluation = expr.manager.get_evaluations_by_id(
+    data_id=0,
+    explainer_id=0,
+    postprocessor_id=0,
+    metric_id=0,
+)
+evaluations = expr.manager.batch_evaluations_by_ids( # batched evaluations
+    data_ids=[0, 1],
+    explainer_id=0,
+    postprocessor_id=0,
+    metric_id=0,
+)
+
+
+
+#------------------------------------------------------------------------------#
+#-------------------------------------- app -----------------------------------#
+#------------------------------------------------------------------------------#
+
+import gradio as gr
+
+# clear results for manual experiment by UI
+expr.manager.clear()
+
+# maps
+nm2cls_explainer = {
+    cls.__name__: cls for cls in expr.recommended.explainers
+}
+nm2obj_postprocessor = {
+    pp.pooling_method: pp for pp in expr.manager.postprocessors
+}
+nm2obj_baseline_fn = {
+    nm: None for nm in ['zeros', 'min', 'channel_min']
+}
+
+# forms
+def change_form_explainer_kwargs(explainer_nm):
+    visible = {
+        'n_steps': explainer_nm in ['IntegratedGradients'],
+        'n_iter': explainer_nm in ['SmoothGrad', 'VarGrad'],
+        'n_samples': explainer_nm in ['Lime', 'KernelShap'],
+        'baseline_fn': explainer_nm in ['IntegratedGradients', 'Lime', 'KernelShap'],
+        'noise_level': explainer_nm in ['SmoothGrad', 'VarGrad'],
+        'epsilon': 'LRP' in explainer_nm,
+        'gamma': explainer_nm in ['LRPEpsilonGammaBox'],
+        'pooling_method': True,
+    }
+    form = {
+        'n_steps': gr.Number(
+            25,
+            label='n_steps',
+            info='The number of approximation steps',
+            visible=visible['n_steps'],
+            interactive=True,
+        ),
+        'n_iter': gr.Number(
+            25,
+            label='n_iter',
+            info='The number of iterations',
+            visible=visible['n_iter'],
+            interactive=True,
+        ),
+        'n_samples': gr.Number(
+            25,
+            label='n_samples',
+            info='The number of samples',
+            visible=visible['n_samples'],
+            interactive=True,
+        ),
+        'baseline_fn': gr.Dropdown(
+            list(nm2obj_baseline_fn),
+            label='baseline_fn',
+            info='Baseline function',
+            visible=visible['baseline_fn'],
+            interactive=True,
+        ),
+        'noise_level': gr.Slider(
+            minimum=0., maximum=1., value=.1, step=.05,
+            label='noise_level',
+            info='Noise level',
+            visible=visible['noise_level'],
+            interactive=True,
+        ),
+        'epsilon': gr.Slider(
+            minimum=0., maximum=1., value=.1, step=.05,
+            label='epsilon',
+            info='Epsilon',
+            visible=visible['epsilon'],
+            interactive=True,
+        ),
+        'gamma': gr.Slider(
+            minimum=0., maximum=1., value=.25, step=.05,
+            label='gamma',
+            info='Gamma',
+            visible=visible['gamma'],
+            interactive=True,
+        ),
+        'pooling_method': gr.Dropdown(
+            list(nm2obj_postprocessor.keys()),
+            label='pooling_method',
+            info='Relevance Pooling Method',
+            visible=visible['pooling_method'],
+            interactive=True,
+        ),
+    }
+    return list(form.values())
+
+
+with gr.Blocks() as demo:
+    explainers = gr.State([])
+    gr.Markdown('## Explainers')
+    with gr.Row():
+        with gr.Column():
+            current_kwargs = gr.State([])
+
+            # create a form of explainer type
+            new_explainer_nm = gr.Dropdown(
+                list(nm2cls_explainer.keys()),
+                label='Explainer Type',
+                info='Recommended Explainers'
+            )
+
+            # create forms of explainer kwargs by explainer type
+            form_explainer_kwargs = change_form_explainer_kwargs('')
+            new_explainer_nm.change(
+                change_form_explainer_kwargs,
+                new_explainer_nm,
+                form_explainer_kwargs
+            )
+
+            # update kwargs on change in user input value
+            def update_current_kwargs(current_kwargs, key, value):
+                current_kwargs.append((key, value))
+                return current_kwargs, key, value
+
+            for form in form_explainer_kwargs:
+                form.change(
+                    update_current_kwargs,
+                    inputs=[current_kwargs, gr.State(form.label), form],
+                    outputs=[current_kwargs, gr.State(form.label), form],
+                )
+
+
+            # add explainer
+            btn_add_explainer = gr.Button('Add Explainer')
+            def add_explainer(explainers, new_explainer_nm, current_kwargs):
+                kwargs = {}
+                for key, value in reversed(current_kwargs):
+                    if kwargs.get(key) is None:
+                        kwargs[key] = value
+                data = {
+                    'explainer_nm': new_explainer_nm,
+                    'kwargs': kwargs,
+                }
+                explainers.append(data)
+                return explainers, new_explainer_nm, current_kwargs
+            btn_add_explainer.click(
+                fn=add_explainer,
+                inputs=[explainers, new_explainer_nm, current_kwargs],
+                outputs=[explainers, new_explainer_nm, current_kwargs],
+            )
+
+        # render the list of explainers added
+        with gr.Column():
+            @gr.render(inputs=explainers)
+            def render_explainers(ls):
+                gr.Markdown(f"### Added")
+                for data in ls:
+                    gr.Textbox(f"{data['explainer_nm']}({', '.join([k+'='+str(v) for k, v in data['kwargs'].items()])})")
+
+        # TODO: submit explainers
+        # TODO: input form and submit inputs
+        # TODO: metric form and submit metrics
+        # TODO: run experiment by expr.run_batch and response results
+
+demo.launch(share=True)

--- a/tutorials/gradio_auto_expr_imagenet_example.py
+++ b/tutorials/gradio_auto_expr_imagenet_example.py
@@ -7,7 +7,7 @@ import torch
 from helpers import load_model_and_dataloader_for_tutorial
 
 device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-model, loader = load_model_and_dataloader_for_tutorial('image', device)
+model, loader, _ = load_model_and_dataloader_for_tutorial('image', device)
 
 
 #------------------------------------------------------------------------------#
@@ -28,43 +28,43 @@ expr = AutoExperiment(
     channel_dim=1,
 )
 
-# run_batch returns a dict of results
-results = expr.run_batch(data_ids=[0, 1], explainer_id=1, postprocessor_id=0, metric_id=1)
+# # run_batch returns a dict of results
+# results = expr.run_batch(data_ids=[0, 1], explainer_id=1, postprocessor_id=0, metric_id=1)
 
-# Also, we can use experiment manager to browse results as follows
-# get data
-data = expr.manager.get_data_by_id(0) # a pair of single instance (input, label)
-batch = expr.manager.batch_data_by_ids(data_ids=[0, 1]) # a batch of multiple instances (inputs, labels)
+# # Also, we can use experiment manager to browse results as follows
+# # get data
+# data = expr.manager.get_data_by_id(0) # a pair of single instance (input, label)
+# batch = expr.manager.batch_data_by_ids(data_ids=[0, 1]) # a batch of multiple instances (inputs, labels)
 
-# get explainer
-explainer = expr.manager.get_explainer_by_id(0)
+# # get explainer
+# explainer = expr.manager.get_explainer_by_id(0)
 
-# get explanation
-attr = expr.manager.get_explanation_by_id(data_id=0, explainer_id=0)
-batched_attrs = expr.manager.batch_explanations_by_ids(data_ids=[0,1], explainer_id) # batched explanations
+# # get explanation
+# attr = expr.manager.get_explanation_by_id(data_id=0, explainer_id=0)
+# batched_attrs = expr.manager.batch_explanations_by_ids(data_ids=[0,1], explainer_id) # batched explanations
 
-# get postprocessor
-postprocessor = expr.manager.get_postprocessor_by_id(0)
+# # get postprocessor
+# postprocessor = expr.manager.get_postprocessor_by_id(0)
 
-# postprocess
-postprocessed = postprocessor(batched_attrs) # Note that this work only for batched attrs
+# # postprocess
+# postprocessed = postprocessor(batched_attrs) # Note that this work only for batched attrs
 
-# get metric
-metric = expr.manager.get_metric_by_id(0)
+# # get metric
+# metric = expr.manager.get_metric_by_id(0)
 
-# get evaluation
-evaluation = expr.manager.get_evaluations_by_id(
-    data_id=0,
-    explainer_id=0,
-    postprocessor_id=0,
-    metric_id=0,
-)
-evaluations = expr.manager.batch_evaluations_by_ids( # batched evaluations
-    data_ids=[0, 1],
-    explainer_id=0,
-    postprocessor_id=0,
-    metric_id=0,
-)
+# # get evaluation
+# evaluation = expr.manager.get_evaluations_by_id(
+#     data_id=0,
+#     explainer_id=0,
+#     postprocessor_id=0,
+#     metric_id=0,
+# )
+# evaluations = expr.manager.batch_evaluations_by_ids( # batched evaluations
+#     data_ids=[0, 1],
+#     explainer_id=0,
+#     postprocessor_id=0,
+#     metric_id=0,
+# )
 
 
 

--- a/tutorials/helpers.py
+++ b/tutorials/helpers.py
@@ -1,13 +1,27 @@
 from typing import Optional, List
 import os
 import json
+import requests
+import functools
+from io import BytesIO
 from pathlib import Path
+from urllib3 import disable_warnings
+from urllib3.exceptions import InsecureRequestWarning
 
+import torch
 import torchvision
 from torch import Tensor
-from torch.utils.data import Dataset, Subset
+from torch.nn.modules import Module
+from torch.utils.data import Dataset, Subset, DataLoader
+from torchtext.datasets import IMDB
+from transformers import BertTokenizer, BertForSequenceClassification
+from transformers import ViltForQuestionAnswering, ViltProcessor
+
+from tqdm import tqdm
 from PIL import Image
 
+
+# datasets
 
 class ImageNetDataset(Dataset):
     def __init__(self, root_dir, transform=None):
@@ -39,13 +53,6 @@ class ImageNetDataset(Dataset):
     def idx_to_label(self, idx):
         return self.idx_to_labels[str(idx)][1]
 
-
-def get_torchvision_model(model_name):
-    weights = torchvision.models.get_model_weights(model_name).DEFAULT
-    model = torchvision.models.get_model(model_name, weights=weights).eval()
-    transform = weights.transforms()
-    return model, transform
-
 def get_imagenet_dataset(
         transform,
         subset_size: int=100, # ignored if indices is not None
@@ -60,6 +67,97 @@ def get_imagenet_dataset(
     subset = Subset(dataset, indices=indices[:subset_size])
     return subset
 
+
+class IMDBDataset(Dataset):
+    def __init__(self, split='test'):
+        super().__init__()
+        data_iter = IMDB(split=split)
+        self.annotations = [(line, label-1) for label, line in tqdm(data_iter)]
+
+    def __len__(self):
+        return len(self.annotations)
+
+    def __getitem__(self, idx):
+        return self.annotations[idx]
+
+
+def get_imdb_dataset(split='test'):
+    return IMDBDataset(split=split)
+
+
+disable_warnings(InsecureRequestWarning)
+
+class VQADataset(Dataset):
+    def __init__(self):
+        super().__init__()
+        res = requests.get('https://visualqa.org/balanced_data.json')
+        self.annotations = eval(res.text)
+
+    def __len__(self):
+        return len(self.annotations)
+
+
+    def __getitem__(self, idx):
+        data = self.annotations[idx]
+        if isinstance(data['original_image'], str):
+            print(f"Requesting {data['original_image']}...")
+            res = requests.get(data['original_image'], verify=False)
+            img = Image.open(BytesIO(res.content)).convert('RGB')
+            data['original_image'] = img
+        return data['original_image'], data['question'], data['original_answer']
+
+
+def get_vqa_dataset():
+    return VQADataset()
+
+
+
+# models
+def get_torchvision_model(model_name):
+    weights = torchvision.models.get_model_weights(model_name).DEFAULT
+    model = torchvision.models.get_model(model_name, weights=weights).eval()
+    transform = weights.transforms()
+    return model, transform
+
+
+class Bert(BertForSequenceClassification):
+    def forward(self, input_ids, token_type_ids, attention_mask):
+        return super().forward(
+            input_ids=input_ids,
+            token_type_ids=token_type_ids,
+            attention_mask=attention_mask
+        ).logits
+
+
+def get_bert_model(model_name, num_labels):
+    return Bert.from_pretrained(model_name, num_labels=num_labels)
+
+
+class Vilt(ViltForQuestionAnswering):
+    def forward(
+        self,
+        pixel_values,
+        input_ids,
+        token_type_ids,
+        attention_mask,
+        pixel_mask,
+    ):
+        return super().forward(
+            input_ids=input_ids,
+            token_type_ids=token_type_ids,
+            attention_mask=attention_mask,
+            pixel_values=pixel_values,
+            pixel_mask=pixel_mask,
+        ).logits
+
+
+def get_vilt_model(model_name):
+    return Vilt.from_pretrained(model_name)
+
+
+
+# utils
+
 img_to_np = lambda img: img.permute(1, 2, 0).detach().numpy()
 
 def denormalize_image(inputs, mean, std):
@@ -68,3 +166,83 @@ def denormalize_image(inputs, mean, std):
         * Tensor(std)[:, None, None]
         + Tensor(mean)[:, None, None]
     )
+
+
+def bert_collate_fn(batch, tokenizer=None):
+    inputs = tokenizer(
+        [d[0] for d in batch],
+        padding=True,
+        truncation=True,
+        return_tensors='pt',
+    )
+    labels = torch.tensor([d[1] for d in batch])
+    return tuple(inputs.values()), labels
+
+
+def get_bert_tokenizer(model_name):
+    return BertTokenizer.from_pretrained(model_name)
+
+
+def get_vilt_processor(model_name):
+    return ViltProcessor.from_pretrained(model_name)
+
+
+def vilt_collate_fn(batch, processor=None, label2id=None):
+    imgs = [d[0] for d in batch]
+    qsts = [d[1] for d in batch]
+    inputs = processor(
+        images=imgs,
+        text=qsts,
+        padding=True,
+        truncation=True,
+        return_tensors='pt',
+    )
+    labels = torch.tensor([label2id[d[2]] for d in batch])
+    return (
+        inputs['pixel_values'],
+        inputs['input_ids'],
+        inputs['token_type_ids'],
+        inputs['attention_mask'],
+        inputs['pixel_mask'],
+        labels,
+    )
+
+
+def load_model_and_dataloader_for_tutorial(modality, device):
+    if modality == 'image':
+        model, transform = get_torchvision_model('resnet18')
+        model = model.to(device)
+        model.eval()
+        dataset = get_imagenet_dataset(transform)
+        loader = DataLoader(dataset, batch_size=8, shuffle=False)
+        return model, loader
+    elif modality == 'text':
+        model = get_bert_model('fabriceyhc/bert-base-uncased-imdb', num_labels=2)
+        model = model.to(device)
+        model.eval()
+        dataset = get_imdb_dataset(split='test')
+        tokenizer = get_bert_tokenizer('fabriceyhc/bert-base-uncased-imdb')
+        loader = DataLoader(
+            dataset,
+            batch_size=8,
+            shuffle=False,
+            collate_fn=functools.partial(bert_collate_fn, tokenizer=tokenizer)
+        )
+        return model, loader, tokenizer
+    elif modality == ('image', 'text'):
+        model = get_vilt_model('dandelin/vilt-b32-finetuned-vqa')
+        model.to(device)
+        model.eval()
+        dataset = get_vqa_dataset()
+        processor = get_vilt_processor('dandelin/vilt-b32-finetuned-vqa')
+        loader = DataLoader(
+            dataset,
+            batch_size=2,
+            shuffle=False,
+            collate_fn=functools.partial(
+                vilt_collate_fn,
+                processor=processor,
+                label2id=model.config.label2id,
+            ),
+        )
+        return model, loader, processor

--- a/tutorials/helpers.py
+++ b/tutorials/helpers.py
@@ -215,7 +215,7 @@ def load_model_and_dataloader_for_tutorial(modality, device):
         model.eval()
         dataset = get_imagenet_dataset(transform)
         loader = DataLoader(dataset, batch_size=8, shuffle=False)
-        return model, loader
+        return model, loader, transform
     elif modality == 'text':
         model = get_bert_model('fabriceyhc/bert-base-uncased-imdb', num_labels=2)
         model = model.to(device)


### PR DESCRIPTION
This PR adds
- pixel flipping metrics: `PixelFlipping`, `MoRF`, `LeRF`, and `AbPC`
- a class for post processing in `AutoExperiment`: `PostProcessor`
- methods to run experiment by batch to `Experiment`: `run_batch`, `explain_batch`, `postprocess_batch`, `evaluate_batch`
- methods to browse results of experiment to `ExperimentManager`
    - `get_data_by_id`, `get_explainer_by_id`, `get_postprocessor_by_id`, `get_metric_by_id`
    - `batch_data_by_ids`, `batch_explanations_by_ids`, `batch_evaluations_by_ids`
    - You can see the example usage of them in `tutorials/gradio_auto_expr_imagenet_example.py`