### PR TITLE
fix: resolve shape error in quickshift for single-channel image inputs

### DIFF
--- a/pnpxai/explainers/utils/feature_masks.py
+++ b/pnpxai/explainers/utils/feature_masks.py
@@ -12,6 +12,8 @@ from pnpxai.evaluator.optimizer.utils import generate_param_key
 
 
 def _skseg_for_tensor(fn, inputs: torch.Tensor, **kwargs):
+    if fn == quickshift:
+        inputs = inputs.tile(1, 3, 1, 1)
     feature_mask = [
         torch.tensor(fn(
             inp.permute(1, 2, 0).detach().cpu().numpy(),


### PR DESCRIPTION
Resolve shape error in quickshift for single-channel image inputs